### PR TITLE
Potatoboard speedrun

### DIFF
--- a/common/board.js
+++ b/common/board.js
@@ -50,6 +50,7 @@ export function boardReactionCount(channel) {
 if (!CONSTANTS.channels.board) throw new ReferenceError("Could not find board channel");
 
 export const boardDatabase = new Database("board");
+export const speedrunDatabase = new Database("potatoboard_speedrun")
 await boardDatabase.init();
 
 /**
@@ -187,6 +188,13 @@ export async function updateBoard(message) {
 			...(await generateBoardMessage(message)),
 			allowedMentions: pings ? undefined : { users: [] },
 		});
+
+		if (potatoboard_speedrun.length === 0 || ((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime()) < speedrunDatabase[0].time) {
+			potatoboard_speedrun = [{ time:  ((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime()) }]
+			await CONSTANTS.channels.announcements.send({
+				content: `<@${message.author.id}>'s message just hit the potatoboard faster than any message before! Only ${((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime())/1000}s!`
+			})
+		}
 
 		if (CONSTANTS.channels.board.type === ChannelType.GuildAnnouncement)
 			promises.push(boardMessage.crosspost());

--- a/common/board.js
+++ b/common/board.js
@@ -189,8 +189,8 @@ export async function updateBoard(message) {
 			allowedMentions: pings ? undefined : { users: [] },
 		});
 
-		if (potatoboard_speedrun.length === 0 || ((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime()) < speedrunDatabase[0].time) {
-			potatoboard_speedrun = [{ time:  ((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime()) }]
+		if (speedrunDatabase.length === 0 || ((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime()) < speedrunDatabase[0].time) {
+			speedrunDatabase = [{ time:  ((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime()) }]
 			await CONSTANTS.channels.announcements.send({
 				content: `<@${message.author.id}>'s message just hit the potatoboard faster than any message before! Only ${((new Date()).getTime() - (new Date(message.createdTimestamp)).getTime())/1000}s!`
 			})

--- a/common/database.ts
+++ b/common/database.ts
@@ -202,4 +202,7 @@ export type Databases = {
 		title: string;
 	};
 	roles: { [role: Snowflake]: true } & { user: Snowflake };
+	potatoboard_speedrun: {
+		time: number;
+	};
 };


### PR DESCRIPTION
### Resolves

An ongoing need for speedy potatoes.

### Changes

This creates a new database for the fastest time, along with detecting if the new message hitting the potatoboard is faster than ever before. It it is, then it sends an alert to the server news channel.