### PR TITLE
Fix Ban Appeals on Fly.io

### DIFF
--- a/util/text.ts
+++ b/util/text.ts
@@ -116,9 +116,8 @@ export function trimPatchVersion(full: string): string {
 export function getRequestUrl(request: IncomingMessage) {
 	return new URL(
 		request.url ?? "",
-		`${
-			request.headers["x-forwarded-proto"] ||
-			`http${"encrypted" in request.socket ? "s" : ""}`
-		}://${request.headers["x-forwarded-host"] || request.headers.host}`,
+		request.headers["x-forwarded-host"]
+			? `${request.headers["x-forwarded-proto"]}://${request.headers["x-forwarded-host"]}`
+			: `http${"encrypted" in request.socket ? "s" : ""}://${request.headers.host}`,
 	);
 }


### PR DESCRIPTION
Tweaks request headers to make ban appeals work again on Fly.io