### PR TITLE
Bump dependencies

### DIFF
--- a/modules/logging/messages.ts
+++ b/modules/logging/messages.ts
@@ -2,7 +2,7 @@ import { unifiedDiff } from "difflib";
 import {
 	Colors,
 	messageLink,
-	type Collection,
+	type ReadonlyCollection,
 	type GuildTextBasedChannel,
 	type Message,
 	type MessageReaction,
@@ -64,7 +64,7 @@ export async function messageDelete(message: Message | PartialMessage): Promise<
 	);
 }
 export async function messageDeleteBulk(
-	messages: Collection<string, Message | PartialMessage>,
+	messages: ReadonlyCollection<string, Message | PartialMessage>,
 	channel: GuildTextBasedChannel,
 ): Promise<void> {
 	if (!shouldLog(channel)) return;
@@ -113,7 +113,7 @@ export async function messageDeleteBulk(
 }
 export async function messageReactionRemoveAll(
 	partialMessage: Message | PartialMessage,
-	reactions: Collection<string, MessageReaction>,
+	reactions: ReadonlyCollection<string, MessageReaction>,
 ): Promise<void> {
 	const message = partialMessage.partial ? await partialMessage.fetch() : partialMessage;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 			"devDependencies": {
 				"@redguy12/prettier-config": "2.0.2",
 				"@types/difflib": "<=0.2",
-				"@types/eslint": "<=8.56",
+				"@types/eslint": "<=8.57",
 				"@types/mustache": "<=4.2",
 				"@types/node": "<=20.10",
 				"@types/papaparse": "<=5.4",
@@ -55,87 +55,16 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.23.4",
-				"chalk": "^2.4.2"
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
@@ -148,14 +77,15 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.22.20",
 				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -233,9 +163,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
-			"integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
+			"integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -244,16 +174,16 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.7.1-dev.1708560541-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.1-dev.1708560541-8c2ababa7.tgz",
-			"integrity": "sha512-JzuLjweS+LxTAEVFVrFK68i8S1tUyKQvYCEnZLQosHBSnD7PpZ4isWUXO60CLRBn9Tf0CDwYJImByqL5cWjWtw==",
+			"version": "1.8.0-dev.1710979856-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.0-dev.1710979856-6cc5fa28e.tgz",
+			"integrity": "sha512-NoiL0QZss3gPLPcqJ4m2WAWa0C4G2r6Dna0BjLuXt8faCDdR16GAxFrtxqg+POFLSxMo8vs0LEfG4U/b4a+BCQ==",
 			"dependencies": {
 				"@discordjs/formatters": "^0.3.3",
 				"@discordjs/util": "^1.0.2",
 				"@sapphire/shapeshift": "^3.9.6",
 				"discord-api-types": "0.37.61",
 				"fast-deep-equal": "^3.1.3",
-				"ts-mixer": "^6.0.3",
+				"ts-mixer": "^6.0.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -261,17 +191,17 @@
 			}
 		},
 		"node_modules/@discordjs/collection": {
-			"version": "2.0.1-dev.1708560543-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.1-dev.1708560543-8c2ababa7.tgz",
-			"integrity": "sha512-TCc3grMqy56YAnLkHrumzvciUtNNa15jwcQ7taOZWl1imKmJxlnJbS/trAQgPox8Dd/Yg+IipW8HNxeuJpdSig==",
+			"version": "2.1.0-dev.1710979855-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0-dev.1710979855-6cc5fa28e.tgz",
+			"integrity": "sha512-csD/IEhiu6AFglstN1RChPXTNC6T7eYcYO00qDaeKWevjVuJADbA7Kw4SydvdmP2GVx200Cd2riKdSIlQEtZmg==",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.3.4-dev.1708560538-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.4-dev.1708560538-8c2ababa7.tgz",
-			"integrity": "sha512-KMMWDy5vlSsirpvPB2xaRsXDf0Yc3jqcr/tTQNlVocMIDBzh5ce22J51FU7Mt9JsCuBHAo2ARQXi9YU7+N5+Zw==",
+			"version": "0.4.0-dev.1710979856-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0-dev.1710979856-6cc5fa28e.tgz",
+			"integrity": "sha512-ZKZitLtmJq/SemqB3UKRkzvYlK1xXzT4awuilqaf/FigbZQGL6m51ESafijbUNtUHc1+GKeK2Nzxc2BxpyvCqQ==",
 			"dependencies": {
 				"discord-api-types": "0.37.61"
 			},
@@ -280,9 +210,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.3.0-dev.1708560547-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1708560547-8c2ababa7.tgz",
-			"integrity": "sha512-yHDCCabbzGmF0Moz9opQUVi1mj2Lty1961dcbLO+pticYBdn5xXcPJOQ6MwdI67Hv0QF6iOHG9eOF/8gmIrgxQ==",
+			"version": "2.3.0-dev.1710979855-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1710979855-6cc5fa28e.tgz",
+			"integrity": "sha512-9xpO1Tl+FxyaIWA9d6/nyq/b4LW+cmufd537XjG0bcMkVYJ8I+4+NjEq53wGfuMmkvITShbxS1EHBrUleSR85g==",
 			"dependencies": {
 				"@discordjs/collection": "^2.0.0",
 				"@discordjs/util": "^1.0.2",
@@ -290,26 +220,26 @@
 				"@sapphire/snowflake": "^3.5.3",
 				"@vladfrangu/async_event_emitter": "^2.2.4",
 				"discord-api-types": "0.37.61",
-				"magic-bytes.js": "^1.8.0",
+				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.2",
-				"undici": "6.6.1"
+				"undici": "6.7.1"
 			},
 			"engines": {
 				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.0-dev.1708560538-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1708560538-8c2ababa7.tgz",
-			"integrity": "sha512-r5+7R12311AKM2QGOI+qBB1QDm28np4saYRjK7eV5ejZ4pvQ77Bjodo3So1rh0tvmc35/rmZOH9HlgzUVDMY5Q==",
+			"version": "1.1.0-dev.1710979853-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1710979853-6cc5fa28e.tgz",
+			"integrity": "sha512-KTSsP/NoluN8kcYzIpyDmaNACqFwjnVtDPC0jcKQuZKAPrA1TtsYf/3ig/h1/yVRyoF6bb+uxqx1F6XnKdK0WQ==",
 			"engines": {
 				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "1.1.0-dev.1708560542-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1708560542-8c2ababa7.tgz",
-			"integrity": "sha512-ygPE3mezmBz2cJ2ZJ3RKFqQrkJzSt9N1xy1Y8xnqoanre7DJlVPbDHu3C2K7ho26Wjy9PHdPr3m9OpQ2pgzXng==",
+			"version": "1.1.0-dev.1710979857-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1710979857-6cc5fa28e.tgz",
+			"integrity": "sha512-G1bl/bSCx/YXEuA/7VLBl9mqAjME4DPNroUWF+eNUDHjRyopZC0Kiy1Zxg+uNqRWtdC47cXaIOjHAwisoaHCeA==",
 			"dependencies": {
 				"@discordjs/collection": "^2.0.0",
 				"@discordjs/rest": "^2.2.0",
@@ -403,14 +333,6 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@fastify/busboy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-			"integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/@fontsource-variable/sora": {
 			"version": "5.0.17",
 			"resolved": "https://registry.npmjs.org/@fontsource-variable/sora/-/sora-5.0.17.tgz",
@@ -494,9 +416,9 @@
 			"integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
-			"integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
+			"integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
 			"optional": true,
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
@@ -786,6 +708,12 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
 			"integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
 			"dev": true
+		},
+		"node_modules/@redguy12/prettier-config/node_modules/@types/prettier": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
+			"integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+			"extraneous": true
 		},
 		"node_modules/@redguy12/prettier-config/node_modules/@types/unist": {
 			"version": "2.0.6",
@@ -1931,9 +1859,9 @@
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.3",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.3.tgz",
-			"integrity": "sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==",
+			"version": "8.56.6",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
+			"integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -1982,9 +1910,9 @@
 			}
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-			"integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
 			"dev": true
 		},
 		"node_modules/@types/webidl-conversions": {
@@ -2089,47 +2017,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
-			"integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
-			"integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "7.3.1",
-				"@typescript-eslint/visitor-keys": "7.3.1",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
@@ -2156,6 +2043,19 @@
 				"@typescript-eslint/types": "7.0.2",
 				"@typescript-eslint/visitor-keys": "7.0.2"
 			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+			"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
 			},
@@ -2191,7 +2091,7 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
 			"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
@@ -2204,7 +2104,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz",
 			"integrity": "sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==",
@@ -2232,6 +2132,64 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
+			"integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
+			"integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "7.3.1",
+				"@typescript-eslint/visitor-keys": "7.3.1",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
+			"integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "7.3.1",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.2.tgz",
@@ -2257,6 +2215,47 @@
 				"eslint": "^8.56.0"
 			}
 		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+			"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+			"dev": true,
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz",
+			"integrity": "sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "7.0.2",
+				"@typescript-eslint/visitor-keys": "7.0.2",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.2.tgz",
@@ -2266,6 +2265,19 @@
 				"@typescript-eslint/types": "7.0.2",
 				"eslint-visitor-keys": "^3.4.1"
 			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+			"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
 			},
@@ -2391,12 +2403,15 @@
 			"dev": true
 		},
 		"node_modules/binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -2482,9 +2497,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001589",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
-			"integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+			"version": "1.0.30001599",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
+			"integrity": "sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2625,12 +2640,12 @@
 			"dev": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.36.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.0.tgz",
-			"integrity": "sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==",
+			"version": "3.36.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
+			"integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.22.3"
+				"browserslist": "^4.23.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2714,9 +2729,9 @@
 			"integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
 		},
 		"node_modules/discord.js": {
-			"version": "14.15.0-dev.1708560537-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1708560537-8c2ababa7.tgz",
-			"integrity": "sha512-clFSmn0/I90D5ZI6r8vzsadAh10QdyjcsMl4asszwrJj/XXNczDeEl1frAGM6l7WMG7tHEzRLHlBbfQzbaOiXg==",
+			"version": "14.15.0-dev.1710979853-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1710979853-6cc5fa28e.tgz",
+			"integrity": "sha512-naS+xioFRz6qMZWo0Cy9M6FqjDL0M945OWzQvCfCxY0aIMSMUQMoCAwFjK04obDOXqKrJjj++BW5+TKU85vY5g==",
 			"dependencies": {
 				"@discordjs/builders": "^1.7.0",
 				"@discordjs/collection": "1.5.3",
@@ -2730,7 +2745,7 @@
 				"fast-deep-equal": "3.1.3",
 				"lodash.snakecase": "4.1.1",
 				"tslib": "2.6.2",
-				"undici": "6.6.1",
+				"undici": "6.7.1",
 				"ws": "8.16.0"
 			},
 			"engines": {
@@ -2801,9 +2816,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.680",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.680.tgz",
-			"integrity": "sha512-4nToZ5jlPO14W82NkF32wyjhYqQByVaDmLy4J2/tYcAbJfgO2TKJC780Az1V13gzq4l73CJ0yuyalpXvxXXD9A==",
+			"version": "1.4.713",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.713.tgz",
+			"integrity": "sha512-vDarADhwntXiULEdmWd77g2dV6FrNGa8ecAC29MZ4TwPut2fvosD0/5sJd1qWNNe8HcJFAC+F5Lf9jW1NPtWmw==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -3300,9 +3315,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-			"integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -3662,9 +3677,9 @@
 			}
 		},
 		"node_modules/magic-bytes.js": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.8.0.tgz",
-			"integrity": "sha512-lyWpfvNGVb5lu8YUAbER0+UMBTdR63w2mcSUlhhBTyVbxJvjgqwyAf3AZD6MprgK0uHuBoWXSDAMWLupX83o3Q=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
 		},
 		"node_modules/match-sorter": {
 			"version": "6.3.4",
@@ -4765,9 +4780,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=16"
@@ -4830,12 +4845,9 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.6.1.tgz",
-			"integrity": "sha512-J0GaEp0ztu/grIE2Uq57AbK6TRb+bWbOlxu0POCzhFKA6LKbwSAev+hDQaQcgUUA9CPs8Ky+cauzTHnQrtAQEA==",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
+			"integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ==",
 			"engines": {
 				"node": ">=18.0"
 			}
@@ -4982,71 +4994,13 @@
 			"dev": true
 		},
 		"@babel/code-frame": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.23.4",
-				"chalk": "^2.4.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/helper-validator-identifier": {
@@ -5056,14 +5010,15 @@
 			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.22.20",
 				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5125,44 +5080,44 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
-			"integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
+			"integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
 			"requires": {
 				"regenerator-runtime": "^0.14.0"
 			}
 		},
 		"@discordjs/builders": {
-			"version": "1.7.1-dev.1708560541-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.1-dev.1708560541-8c2ababa7.tgz",
-			"integrity": "sha512-JzuLjweS+LxTAEVFVrFK68i8S1tUyKQvYCEnZLQosHBSnD7PpZ4isWUXO60CLRBn9Tf0CDwYJImByqL5cWjWtw==",
+			"version": "1.8.0-dev.1710979856-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.0-dev.1710979856-6cc5fa28e.tgz",
+			"integrity": "sha512-NoiL0QZss3gPLPcqJ4m2WAWa0C4G2r6Dna0BjLuXt8faCDdR16GAxFrtxqg+POFLSxMo8vs0LEfG4U/b4a+BCQ==",
 			"requires": {
 				"@discordjs/formatters": "dev",
 				"@discordjs/util": "dev",
 				"@sapphire/shapeshift": "^3.9.6",
 				"discord-api-types": "0.37.61",
 				"fast-deep-equal": "^3.1.3",
-				"ts-mixer": "^6.0.3",
+				"ts-mixer": "^6.0.4",
 				"tslib": "^2.6.2"
 			}
 		},
 		"@discordjs/collection": {
-			"version": "2.0.1-dev.1708560543-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.1-dev.1708560543-8c2ababa7.tgz",
-			"integrity": "sha512-TCc3grMqy56YAnLkHrumzvciUtNNa15jwcQ7taOZWl1imKmJxlnJbS/trAQgPox8Dd/Yg+IipW8HNxeuJpdSig=="
+			"version": "2.1.0-dev.1710979855-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0-dev.1710979855-6cc5fa28e.tgz",
+			"integrity": "sha512-csD/IEhiu6AFglstN1RChPXTNC6T7eYcYO00qDaeKWevjVuJADbA7Kw4SydvdmP2GVx200Cd2riKdSIlQEtZmg=="
 		},
 		"@discordjs/formatters": {
-			"version": "0.3.4-dev.1708560538-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.4-dev.1708560538-8c2ababa7.tgz",
-			"integrity": "sha512-KMMWDy5vlSsirpvPB2xaRsXDf0Yc3jqcr/tTQNlVocMIDBzh5ce22J51FU7Mt9JsCuBHAo2ARQXi9YU7+N5+Zw==",
+			"version": "0.4.0-dev.1710979856-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0-dev.1710979856-6cc5fa28e.tgz",
+			"integrity": "sha512-ZKZitLtmJq/SemqB3UKRkzvYlK1xXzT4awuilqaf/FigbZQGL6m51ESafijbUNtUHc1+GKeK2Nzxc2BxpyvCqQ==",
 			"requires": {
 				"discord-api-types": "0.37.61"
 			}
 		},
 		"@discordjs/rest": {
-			"version": "2.3.0-dev.1708560547-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1708560547-8c2ababa7.tgz",
-			"integrity": "sha512-yHDCCabbzGmF0Moz9opQUVi1mj2Lty1961dcbLO+pticYBdn5xXcPJOQ6MwdI67Hv0QF6iOHG9eOF/8gmIrgxQ==",
+			"version": "2.3.0-dev.1710979855-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1710979855-6cc5fa28e.tgz",
+			"integrity": "sha512-9xpO1Tl+FxyaIWA9d6/nyq/b4LW+cmufd537XjG0bcMkVYJ8I+4+NjEq53wGfuMmkvITShbxS1EHBrUleSR85g==",
 			"requires": {
 				"@discordjs/collection": "dev",
 				"@discordjs/util": "dev",
@@ -5170,20 +5125,20 @@
 				"@sapphire/snowflake": "^3.5.3",
 				"@vladfrangu/async_event_emitter": "^2.2.4",
 				"discord-api-types": "0.37.61",
-				"magic-bytes.js": "^1.8.0",
+				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.2",
-				"undici": "6.6.1"
+				"undici": "6.7.1"
 			}
 		},
 		"@discordjs/util": {
-			"version": "1.1.0-dev.1708560538-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1708560538-8c2ababa7.tgz",
-			"integrity": "sha512-r5+7R12311AKM2QGOI+qBB1QDm28np4saYRjK7eV5ejZ4pvQ77Bjodo3So1rh0tvmc35/rmZOH9HlgzUVDMY5Q=="
+			"version": "1.1.0-dev.1710979853-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1710979853-6cc5fa28e.tgz",
+			"integrity": "sha512-KTSsP/NoluN8kcYzIpyDmaNACqFwjnVtDPC0jcKQuZKAPrA1TtsYf/3ig/h1/yVRyoF6bb+uxqx1F6XnKdK0WQ=="
 		},
 		"@discordjs/ws": {
-			"version": "1.1.0-dev.1708560542-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1708560542-8c2ababa7.tgz",
-			"integrity": "sha512-ygPE3mezmBz2cJ2ZJ3RKFqQrkJzSt9N1xy1Y8xnqoanre7DJlVPbDHu3C2K7ho26Wjy9PHdPr3m9OpQ2pgzXng==",
+			"version": "1.1.0-dev.1710979857-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1710979857-6cc5fa28e.tgz",
+			"integrity": "sha512-G1bl/bSCx/YXEuA/7VLBl9mqAjME4DPNroUWF+eNUDHjRyopZC0Kiy1Zxg+uNqRWtdC47cXaIOjHAwisoaHCeA==",
 			"requires": {
 				"@discordjs/collection": "dev",
 				"@discordjs/rest": "dev",
@@ -5255,11 +5210,6 @@
 			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"dev": true
 		},
-		"@fastify/busboy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-			"integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA=="
-		},
 		"@fontsource-variable/sora": {
 			"version": "5.0.17",
 			"resolved": "https://registry.npmjs.org/@fontsource-variable/sora/-/sora-5.0.17.tgz",
@@ -5328,9 +5278,9 @@
 			"integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
 		},
 		"@mongodb-js/saslprep": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
-			"integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
+			"integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
 			"optional": true,
 			"requires": {
 				"sparse-bitfield": "^3.0.3"
@@ -5514,6 +5464,11 @@
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
 					"integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
 					"dev": true
+				},
+				"@types/prettier": {
+					"version": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
+					"integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+					"extraneous": true
 				},
 				"@types/unist": {
 					"version": "2.0.6",
@@ -6252,9 +6207,9 @@
 			"dev": true
 		},
 		"@types/eslint": {
-			"version": "8.56.3",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.3.tgz",
-			"integrity": "sha512-PvSf1wfv2wJpVIFUMSb+i4PvqNYkB9Rkp9ZDO3oaWzq4SKhsQk4mrMBr3ZH06I0hKrVGLBacmgl8JM4WVjb9dg==",
+			"version": "8.56.6",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
+			"integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -6303,9 +6258,9 @@
 			}
 		},
 		"@types/semver": {
-			"version": "7.5.7",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-			"integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
 			"dev": true
 		},
 		"@types/webidl-conversions": {
@@ -6372,28 +6327,6 @@
 						"@typescript-eslint/visitor-keys": "7.3.1"
 					}
 				},
-				"@typescript-eslint/types": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
-					"integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
-					"dev": true
-				},
-				"@typescript-eslint/typescript-estree": {
-					"version": "7.3.1",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
-					"integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
-					"dev": true,
-					"requires": {
-						"@typescript-eslint/types": "7.3.1",
-						"@typescript-eslint/visitor-keys": "7.3.1",
-						"debug": "^4.3.4",
-						"globby": "^11.1.0",
-						"is-glob": "^4.0.3",
-						"minimatch": "9.0.3",
-						"semver": "^7.5.4",
-						"ts-api-utils": "^1.0.1"
-					}
-				},
 				"@typescript-eslint/visitor-keys": {
 					"version": "7.3.1",
 					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
@@ -6414,6 +6347,14 @@
 			"requires": {
 				"@typescript-eslint/types": "7.0.2",
 				"@typescript-eslint/visitor-keys": "7.0.2"
+			},
+			"dependencies": {
+				"@typescript-eslint/types": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+					"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+					"dev": true
+				}
 			}
 		},
 		"@typescript-eslint/type-utils": {
@@ -6426,28 +6367,64 @@
 				"@typescript-eslint/utils": "7.0.2",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@typescript-eslint/types": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+					"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz",
+					"integrity": "sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "7.0.2",
+						"@typescript-eslint/visitor-keys": "7.0.2",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"minimatch": "9.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
-			"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.3.1.tgz",
+			"integrity": "sha512-2tUf3uWggBDl4S4183nivWQ2HqceOZh1U4hhu4p1tPiIJoRRXrab7Y+Y0p+dozYwZVvLPRI6r5wKe9kToF9FIw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz",
-			"integrity": "sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.3.1.tgz",
+			"integrity": "sha512-tLpuqM46LVkduWP7JO7yVoWshpJuJzxDOPYIVWUUZbW+4dBpgGeUdl/fQkhuV0A8eGnphYw3pp8d2EnvPOfxmQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "7.0.2",
-				"@typescript-eslint/visitor-keys": "7.0.2",
+				"@typescript-eslint/types": "7.3.1",
+				"@typescript-eslint/visitor-keys": "7.3.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
 				"minimatch": "9.0.3",
 				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"@typescript-eslint/visitor-keys": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.3.1.tgz",
+					"integrity": "sha512-9RMXwQF8knsZvfv9tdi+4D/j7dMG28X/wMJ8Jj6eOHyHWwDW4ngQJcqEczSsqIKKjFiLFr40Mnr7a5ulDD3vmw==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "7.3.1",
+						"eslint-visitor-keys": "^3.4.1"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/utils": {
@@ -6463,6 +6440,30 @@
 				"@typescript-eslint/types": "7.0.2",
 				"@typescript-eslint/typescript-estree": "7.0.2",
 				"semver": "^7.5.4"
+			},
+			"dependencies": {
+				"@typescript-eslint/types": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+					"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz",
+					"integrity": "sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "7.0.2",
+						"@typescript-eslint/visitor-keys": "7.0.2",
+						"debug": "^4.3.4",
+						"globby": "^11.1.0",
+						"is-glob": "^4.0.3",
+						"minimatch": "9.0.3",
+						"semver": "^7.5.4",
+						"ts-api-utils": "^1.0.1"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
@@ -6473,6 +6474,14 @@
 			"requires": {
 				"@typescript-eslint/types": "7.0.2",
 				"eslint-visitor-keys": "^3.4.1"
+			},
+			"dependencies": {
+				"@typescript-eslint/types": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
+					"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
+					"dev": true
+				}
 			}
 		},
 		"@ungap/structured-clone": {
@@ -6561,9 +6570,9 @@
 			"dev": true
 		},
 		"binary-extensions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -6614,9 +6623,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001589",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
-			"integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+			"version": "1.0.30001599",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
+			"integrity": "sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==",
 			"dev": true
 		},
 		"chalk": {
@@ -6709,12 +6718,12 @@
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.36.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.0.tgz",
-			"integrity": "sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==",
+			"version": "3.36.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
+			"integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.22.3"
+				"browserslist": "^4.23.0"
 			}
 		},
 		"cross-spawn": {
@@ -6775,9 +6784,9 @@
 			"integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
 		},
 		"discord.js": {
-			"version": "14.15.0-dev.1708560537-8c2ababa7",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1708560537-8c2ababa7.tgz",
-			"integrity": "sha512-clFSmn0/I90D5ZI6r8vzsadAh10QdyjcsMl4asszwrJj/XXNczDeEl1frAGM6l7WMG7tHEzRLHlBbfQzbaOiXg==",
+			"version": "14.15.0-dev.1710979853-6cc5fa28e",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1710979853-6cc5fa28e.tgz",
+			"integrity": "sha512-naS+xioFRz6qMZWo0Cy9M6FqjDL0M945OWzQvCfCxY0aIMSMUQMoCAwFjK04obDOXqKrJjj++BW5+TKU85vY5g==",
 			"requires": {
 				"@discordjs/builders": "dev",
 				"@discordjs/collection": "dev",
@@ -6791,7 +6800,7 @@
 				"fast-deep-equal": "3.1.3",
 				"lodash.snakecase": "4.1.1",
 				"tslib": "2.6.2",
-				"undici": "6.6.1",
+				"undici": "6.7.1",
 				"ws": "8.16.0"
 			}
 		},
@@ -6838,9 +6847,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.680",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.680.tgz",
-			"integrity": "sha512-4nToZ5jlPO14W82NkF32wyjhYqQByVaDmLy4J2/tYcAbJfgO2TKJC780Az1V13gzq4l73CJ0yuyalpXvxXXD9A==",
+			"version": "1.4.713",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.713.tgz",
+			"integrity": "sha512-vDarADhwntXiULEdmWd77g2dV6FrNGa8ecAC29MZ4TwPut2fvosD0/5sJd1qWNNe8HcJFAC+F5Lf9jW1NPtWmw==",
 			"dev": true
 		},
 		"entities": {
@@ -7216,9 +7225,9 @@
 			"dev": true
 		},
 		"hasown": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-			"integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.2"
@@ -7499,9 +7508,9 @@
 			}
 		},
 		"magic-bytes.js": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.8.0.tgz",
-			"integrity": "sha512-lyWpfvNGVb5lu8YUAbER0+UMBTdR63w2mcSUlhhBTyVbxJvjgqwyAf3AZD6MprgK0uHuBoWXSDAMWLupX83o3Q=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
 		},
 		"match-sorter": {
 			"version": "6.3.4",
@@ -8286,9 +8295,9 @@
 			}
 		},
 		"ts-api-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
-			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
 			"dev": true,
 			"requires": {}
 		},
@@ -8330,12 +8339,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.6.1.tgz",
-			"integrity": "sha512-J0GaEp0ztu/grIE2Uq57AbK6TRb+bWbOlxu0POCzhFKA6LKbwSAev+hDQaQcgUUA9CPs8Ky+cauzTHnQrtAQEA==",
-			"requires": {
-				"@fastify/busboy": "^2.0.0"
-			}
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.7.1.tgz",
+			"integrity": "sha512-+Wtb9bAQw6HYWzCnxrPTMVEV3Q1QjYanI0E4q02ehReMuquQdLTEFEYbfs7hcImVYKcQkWSwT6buEmSVIiDDtQ=="
 		},
 		"undici-types": {
 			"version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@redguy12/prettier-config": "2.0.2",
 		"@types/difflib": "<=0.2",
-		"@types/eslint": "<=8.56",
+		"@types/eslint": "<=8.57",
 		"@types/mustache": "<=4.2",
 		"@types/node": "<=20.10",
 		"@types/papaparse": "<=5.4",


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@babel/code-frame@7.23.5`](https://npmjs.com/package/@babel/code-frame/v/7.23.5) to [`7.24.2`](https://npmjs.com/package/@babel/code-frame/v/7.24.2) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-code-frame))
- Bumped [`@babel/highlight@7.23.4`](https://npmjs.com/package/@babel/highlight/v/7.23.4) to [`7.24.2`](https://npmjs.com/package/@babel/highlight/v/7.24.2) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-highlight))
- Bumped [`@babel/runtime@7.23.9`](https://npmjs.com/package/@babel/runtime/v/7.23.9) to [`7.24.1`](https://npmjs.com/package/@babel/runtime/v/7.24.1) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-runtime))
- Bumped [`@discordjs/builders@1.7.1-dev.1708560541-8c2ababa7`](https://npmjs.com/package/@discordjs/builders/v/1.7.1-dev.1708560541-8c2ababa7) to [`1.8.0-dev.1710979856-6cc5fa28e`](https://npmjs.com/package/@discordjs/builders/v/1.8.0-dev.1710979856-6cc5fa28e) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/builders))
- Bumped [`@discordjs/collection@2.0.1-dev.1708560543-8c2ababa7`](https://npmjs.com/package/@discordjs/collection/v/2.0.1-dev.1708560543-8c2ababa7) to [`2.1.0-dev.1710979855-6cc5fa28e`](https://npmjs.com/package/@discordjs/collection/v/2.1.0-dev.1710979855-6cc5fa28e) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/collection))
- Bumped [`@discordjs/formatters@0.3.4-dev.1708560538-8c2ababa7`](https://npmjs.com/package/@discordjs/formatters/v/0.3.4-dev.1708560538-8c2ababa7) to [`0.4.0-dev.1710979856-6cc5fa28e`](https://npmjs.com/package/@discordjs/formatters/v/0.4.0-dev.1710979856-6cc5fa28e) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.3.0-dev.1708560547-8c2ababa7`](https://npmjs.com/package/@discordjs/rest/v/2.3.0-dev.1708560547-8c2ababa7) to [`2.3.0-dev.1710979855-6cc5fa28e`](https://npmjs.com/package/@discordjs/rest/v/2.3.0-dev.1710979855-6cc5fa28e) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.0-dev.1708560538-8c2ababa7`](https://npmjs.com/package/@discordjs/util/v/1.1.0-dev.1708560538-8c2ababa7) to [`1.1.0-dev.1710979853-6cc5fa28e`](https://npmjs.com/package/@discordjs/util/v/1.1.0-dev.1710979853-6cc5fa28e) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@discordjs/ws@1.1.0-dev.1708560542-8c2ababa7`](https://npmjs.com/package/@discordjs/ws/v/1.1.0-dev.1708560542-8c2ababa7) to [`1.1.0-dev.1710979857-6cc5fa28e`](https://npmjs.com/package/@discordjs/ws/v/1.1.0-dev.1710979857-6cc5fa28e) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/ws))
- Bumped [`@mongodb-js/saslprep@1.1.4`](https://npmjs.com/package/@mongodb-js/saslprep/v/1.1.4) to [`1.1.5`](https://npmjs.com/package/@mongodb-js/saslprep/v/1.1.5) ([see recent commits](https://github.com/mongodb-js/devtools-shared))
- Installed [`@types/prettier@2.7.1`](https://npmjs.com/package/@types/prettier/v/2.7.1)
- Bumped [`@types/eslint@8.56.3`](https://npmjs.com/package/@types/eslint/v/8.56.3) to [`8.56.6`](https://npmjs.com/package/@types/eslint/v/8.56.6) ([see recent commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/eslint))
- Bumped [`@types/semver@7.5.7`](https://npmjs.com/package/@types/semver/v/7.5.7) to [`7.5.8`](https://npmjs.com/package/@types/semver/v/7.5.8) ([see recent commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/semver))
- Installed [`@typescript-eslint/types@7.0.2`](https://npmjs.com/package/@typescript-eslint/types/v/7.0.2)
- Installed [`@typescript-eslint/typescript-estree@7.0.2`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.0.2)
- Bumped [`@typescript-eslint/types@7.0.2`](https://npmjs.com/package/@typescript-eslint/types/v/7.0.2) to [`7.3.1`](https://npmjs.com/package/@typescript-eslint/types/v/7.3.1) ([see recent commits](https://github.com/typescript-eslint/typescript-eslint/commits/HEAD/packages/types))
- Bumped [`@typescript-eslint/typescript-estree@7.0.2`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.0.2) to [`7.3.1`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.3.1) ([see recent commits](https://github.com/typescript-eslint/typescript-eslint/commits/HEAD/packages/typescript-estree))
- Installed [`@typescript-eslint/visitor-keys@7.3.1`](https://npmjs.com/package/@typescript-eslint/visitor-keys/v/7.3.1)
- Bumped [`binary-extensions@2.2.0`](https://npmjs.com/package/binary-extensions/v/2.2.0) to [`2.3.0`](https://npmjs.com/package/binary-extensions/v/2.3.0) ([see recent commits](https://github.com/sindresorhus/binary-extensions))
- Bumped [`caniuse-lite@1.0.30001589`](https://npmjs.com/package/caniuse-lite/v/1.0.30001589) to [`1.0.30001599`](https://npmjs.com/package/caniuse-lite/v/1.0.30001599) ([see recent commits](https://github.com/browserslist/caniuse-lite))
- Bumped [`core-js-compat@3.36.0`](https://npmjs.com/package/core-js-compat/v/3.36.0) to [`3.36.1`](https://npmjs.com/package/core-js-compat/v/3.36.1) ([see recent commits](https://github.com/zloirock/core-js/commits/HEAD/packages/core-js-compat))
- Bumped [`discord.js@14.15.0-dev.1708560537-8c2ababa7`](https://npmjs.com/package/discord.js/v/14.15.0-dev.1708560537-8c2ababa7) to [`14.15.0-dev.1710979853-6cc5fa28e`](https://npmjs.com/package/discord.js/v/14.15.0-dev.1710979853-6cc5fa28e) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/discord.js))
- Bumped [`electron-to-chromium@1.4.680`](https://npmjs.com/package/electron-to-chromium/v/1.4.680) to [`1.4.713`](https://npmjs.com/package/electron-to-chromium/v/1.4.713) ([see recent commits](https://github.com/kilian/electron-to-chromium))
- Bumped [`hasown@2.0.1`](https://npmjs.com/package/hasown/v/2.0.1) to [`2.0.2`](https://npmjs.com/package/hasown/v/2.0.2) ([see recent commits](https://github.com/inspect-js/hasOwn))
- Bumped [`magic-bytes.js@1.8.0`](https://npmjs.com/package/magic-bytes.js/v/1.8.0) to [`1.10.0`](https://npmjs.com/package/magic-bytes.js/v/1.10.0) ([see recent commits](https://github.com/LarsKoelpin/magic-bytes))
- Bumped [`ts-api-utils@1.2.1`](https://npmjs.com/package/ts-api-utils/v/1.2.1) to [`1.3.0`](https://npmjs.com/package/ts-api-utils/v/1.3.0) ([see recent commits](https://github.com/JoshuaKGoldberg/ts-api-utils))
- Bumped [`undici@6.6.1`](https://npmjs.com/package/undici/v/6.6.1) to [`6.7.1`](https://npmjs.com/package/undici/v/6.7.1) ([see recent commits](https://github.com/nodejs/undici))
- Removed [`ansi-styles@3.2.1`](https://npmjs.com/package/ansi-styles/v/3.2.1)
- Removed [`chalk@2.4.2`](https://npmjs.com/package/chalk/v/2.4.2)
- Removed [`color-convert@1.9.3`](https://npmjs.com/package/color-convert/v/1.9.3)
- Removed [`color-name@1.1.3`](https://npmjs.com/package/color-name/v/1.1.3)
- Removed [`escape-string-regexp@1.0.5`](https://npmjs.com/package/escape-string-regexp/v/1.0.5)
- Removed [`has-flag@3.0.0`](https://npmjs.com/package/has-flag/v/3.0.0)
- Removed [`supports-color@5.5.0`](https://npmjs.com/package/supports-color/v/5.5.0)
- Removed [`@fastify/busboy@2.1.0`](https://npmjs.com/package/@fastify/busboy/v/2.1.0)
- Removed [`@typescript-eslint/types@7.3.1`](https://npmjs.com/package/@typescript-eslint/types/v/7.3.1)
- Removed [`@typescript-eslint/typescript-estree@7.3.1`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.3.1)
</details><details><summary>Requirement changes</summary>

- **@types/eslint**: requirement changed from `<=8.56` to `<=8.57`
</details>
