### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2497,9 +2497,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001599",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
-			"integrity": "sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==",
+			"version": "1.0.30001600",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2816,9 +2816,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.713",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.713.tgz",
-			"integrity": "sha512-vDarADhwntXiULEdmWd77g2dV6FrNGa8ecAC29MZ4TwPut2fvosD0/5sJd1qWNNe8HcJFAC+F5Lf9jW1NPtWmw==",
+			"version": "1.4.715",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
+			"integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -6623,9 +6623,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001599",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001599.tgz",
-			"integrity": "sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==",
+			"version": "1.0.30001600",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+			"integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
 			"dev": true
 		},
 		"chalk": {
@@ -6847,9 +6847,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.713",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.713.tgz",
-			"integrity": "sha512-vDarADhwntXiULEdmWd77g2dV6FrNGa8ecAC29MZ4TwPut2fvosD0/5sJd1qWNNe8HcJFAC+F5Lf9jW1NPtWmw==",
+			"version": "1.4.715",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
+			"integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==",
 			"dev": true
 		},
 		"entities": {


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`caniuse-lite@1.0.30001599`](https://npmjs.com/package/caniuse-lite/v/1.0.30001599) to [`1.0.30001600`](https://npmjs.com/package/caniuse-lite/v/1.0.30001600) ([see recent commits](https://github.com/browserslist/caniuse-lite))
- Bumped [`electron-to-chromium@1.4.713`](https://npmjs.com/package/electron-to-chromium/v/1.4.713) to [`1.4.715`](https://npmjs.com/package/electron-to-chromium/v/1.4.715) ([see recent commits](https://github.com/kilian/electron-to-chromium))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
