### PR TITLE
Bump dependencies

### DIFF
--- a/common/config.ts
+++ b/common/config.ts
@@ -32,7 +32,7 @@ async function getConfig() {
 		otherGuildIds: otherGuilds ? [...otherGuilds.keys()] : [],
 		testingGuild:
 			guild && (await client.guilds.fetch("938438560925761619").catch(() => void 0)),
-		saDevGuildId:"751206349614088204",
+		saDevGuildId: "751206349614088204",
 
 		channels: {
 			info: getChannel("Info", ChannelType.GuildCategory, "start"),

--- a/modules/automod/bad-words.ts
+++ b/modules/automod/bad-words.ts
@@ -6,7 +6,7 @@
  *
  * All RegExps are ROT13-encoded. Additionally, RegExp character classes are not supported here. Use capture groups instead.
  */
-const badWords: [RegExp[],RegExp[],RegExp[],][] = [
+const badWords: [RegExp[], RegExp[], RegExp[]][] = [
 	[[], [], []],
 	[[], [], []],
 	[[], [], []],

--- a/modules/execute/operations/debug-bad-words.ts
+++ b/modules/execute/operations/debug-bad-words.ts
@@ -23,7 +23,7 @@ const data: CustomOperation = {
 
 	async command(interaction, { string }) {
 		assert(typeof string === "string");
-		
+
 		if (
 			config.roles.staff &&
 			!(interaction.member instanceof GuildMember

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,9 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@railway/cli": "3.5.2"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -174,9 +177,9 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.8.0-dev.1710979856-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.0-dev.1710979856-6cc5fa28e.tgz",
-			"integrity": "sha512-NoiL0QZss3gPLPcqJ4m2WAWa0C4G2r6Dna0BjLuXt8faCDdR16GAxFrtxqg+POFLSxMo8vs0LEfG4U/b4a+BCQ==",
+			"version": "1.8.0-dev.1711325431-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.0-dev.1711325431-a1a3a95c9.tgz",
+			"integrity": "sha512-wPmqhdi/JCVbL80mXD5a5tWJgqm/OhUzdWosEs7zSmjHkuLPkm4ycKbC+7bUX/FPhN70O1vhSkRl1rUV2h/5GA==",
 			"dependencies": {
 				"@discordjs/formatters": "^0.3.3",
 				"@discordjs/util": "^1.0.2",
@@ -191,17 +194,17 @@
 			}
 		},
 		"node_modules/@discordjs/collection": {
-			"version": "2.1.0-dev.1710979855-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0-dev.1710979855-6cc5fa28e.tgz",
-			"integrity": "sha512-csD/IEhiu6AFglstN1RChPXTNC6T7eYcYO00qDaeKWevjVuJADbA7Kw4SydvdmP2GVx200Cd2riKdSIlQEtZmg==",
+			"version": "2.1.0-dev.1711325413-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0-dev.1711325413-a1a3a95c9.tgz",
+			"integrity": "sha512-Vle3SIBySAuBlK4ZyA6xaw2FCXnjHk9CSXAaY+mzK03DeiDAB4qMvMwpyMdE3TJEqwP//D8ZPTnQ49sG5a5oBg==",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.4.0-dev.1710979856-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0-dev.1710979856-6cc5fa28e.tgz",
-			"integrity": "sha512-ZKZitLtmJq/SemqB3UKRkzvYlK1xXzT4awuilqaf/FigbZQGL6m51ESafijbUNtUHc1+GKeK2Nzxc2BxpyvCqQ==",
+			"version": "0.4.0-dev.1711325408-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0-dev.1711325408-a1a3a95c9.tgz",
+			"integrity": "sha512-lZkX5D/oKBlsCZuHDPLPwWEXeMox229OlKRzBZEjKjf7cWq89qZw9R2L8IA82ZaaU6f8wgjH59gKSFubF2c/Kg==",
 			"dependencies": {
 				"discord-api-types": "0.37.61"
 			},
@@ -210,9 +213,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.3.0-dev.1710979855-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1710979855-6cc5fa28e.tgz",
-			"integrity": "sha512-9xpO1Tl+FxyaIWA9d6/nyq/b4LW+cmufd537XjG0bcMkVYJ8I+4+NjEq53wGfuMmkvITShbxS1EHBrUleSR85g==",
+			"version": "2.3.0-dev.1711325406-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1711325406-a1a3a95c9.tgz",
+			"integrity": "sha512-2zzb/1Zrw7gw8KKOf2XcSGQ2IF22kt2VhUdnTRTtDqUkrR8DSiIMuQGU+JckndIMC5LXZmdfWxwbeCHelzPfdQ==",
 			"dependencies": {
 				"@discordjs/collection": "^2.0.0",
 				"@discordjs/util": "^1.0.2",
@@ -229,17 +232,17 @@
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.0-dev.1710979853-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1710979853-6cc5fa28e.tgz",
-			"integrity": "sha512-KTSsP/NoluN8kcYzIpyDmaNACqFwjnVtDPC0jcKQuZKAPrA1TtsYf/3ig/h1/yVRyoF6bb+uxqx1F6XnKdK0WQ==",
+			"version": "1.1.0-dev.1711325410-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1711325410-a1a3a95c9.tgz",
+			"integrity": "sha512-kT+GULg3dBlmv28H39BiHAdkaXdx9Je0JKgI/K1w+qm2z0ODPdVo6es/m23v7yBDlW4GxV3zwZnE5hkzkZqVkw==",
 			"engines": {
 				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "1.1.0-dev.1710979857-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1710979857-6cc5fa28e.tgz",
-			"integrity": "sha512-G1bl/bSCx/YXEuA/7VLBl9mqAjME4DPNroUWF+eNUDHjRyopZC0Kiy1Zxg+uNqRWtdC47cXaIOjHAwisoaHCeA==",
+			"version": "1.1.0-dev.1711325409-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1711325409-a1a3a95c9.tgz",
+			"integrity": "sha512-lulTCPr0SUv11KMeY4UuZCk5j+whI9gLMrMoFz1L8Qj3Dmyk8LNZAGKlv8uer89n75Qus6dH50FlIN+uCcUTFQ==",
 			"dependencies": {
 				"@discordjs/collection": "^2.0.0",
 				"@discordjs/rest": "^2.2.0",
@@ -578,6 +581,12 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/@napi-rs/triples": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.2.0.tgz",
+			"integrity": "sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==",
+			"optional": true
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -611,6 +620,24 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@railway/cli": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@railway/cli/-/cli-3.5.2.tgz",
+			"integrity": "sha512-N1F1RMP8RaiNBS0qBfbc1wBROyz4jD9LRyQRHEZTz4Xlg4Rj7O3yyMi36oROfVxk50MGEDKK8Bx/GR3qBUWE1A==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/triples": "^1.1.0",
+				"node-fetch": "^3.1.0",
+				"tar": "^6.1.11"
+			},
+			"bin": {
+				"railway": "bin/railway.js"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@redguy12/prettier-config": {
@@ -2579,6 +2606,15 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ci-info": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
@@ -2666,6 +2702,15 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"optional": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2729,9 +2774,9 @@
 			"integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
 		},
 		"node_modules/discord.js": {
-			"version": "14.15.0-dev.1710979853-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1710979853-6cc5fa28e.tgz",
-			"integrity": "sha512-naS+xioFRz6qMZWo0Cy9M6FqjDL0M945OWzQvCfCxY0aIMSMUQMoCAwFjK04obDOXqKrJjj++BW5+TKU85vY5g==",
+			"version": "14.15.0-dev.1711325411-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1711325411-a1a3a95c9.tgz",
+			"integrity": "sha512-ntaGCvmGCSwlNS1YB94OI5Wxjrj5zWDde/+hdYB04eTxFjdTs0nUZV7ocKKk+/qyYm2C/UY3hRaO/Qh/QcmCTw==",
 			"dependencies": {
 				"@discordjs/builders": "^1.7.0",
 				"@discordjs/collection": "1.5.3",
@@ -3121,6 +3166,29 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"optional": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3180,6 +3248,42 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
 			"dev": true
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"optional": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -3742,6 +3846,52 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"optional": true,
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/mongodb": {
 			"version": "5.9.0",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
@@ -3854,6 +4004,43 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"optional": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"optional": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.14",
@@ -4738,6 +4925,23 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/tar": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"optional": true,
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4906,6 +5110,15 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"optional": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/webidl-conversions": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -4971,7 +5184,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
@@ -5088,9 +5301,9 @@
 			}
 		},
 		"@discordjs/builders": {
-			"version": "1.8.0-dev.1710979856-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.0-dev.1710979856-6cc5fa28e.tgz",
-			"integrity": "sha512-NoiL0QZss3gPLPcqJ4m2WAWa0C4G2r6Dna0BjLuXt8faCDdR16GAxFrtxqg+POFLSxMo8vs0LEfG4U/b4a+BCQ==",
+			"version": "1.8.0-dev.1711325431-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.0-dev.1711325431-a1a3a95c9.tgz",
+			"integrity": "sha512-wPmqhdi/JCVbL80mXD5a5tWJgqm/OhUzdWosEs7zSmjHkuLPkm4ycKbC+7bUX/FPhN70O1vhSkRl1rUV2h/5GA==",
 			"requires": {
 				"@discordjs/formatters": "dev",
 				"@discordjs/util": "dev",
@@ -5102,22 +5315,22 @@
 			}
 		},
 		"@discordjs/collection": {
-			"version": "2.1.0-dev.1710979855-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0-dev.1710979855-6cc5fa28e.tgz",
-			"integrity": "sha512-csD/IEhiu6AFglstN1RChPXTNC6T7eYcYO00qDaeKWevjVuJADbA7Kw4SydvdmP2GVx200Cd2riKdSIlQEtZmg=="
+			"version": "2.1.0-dev.1711325413-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.0-dev.1711325413-a1a3a95c9.tgz",
+			"integrity": "sha512-Vle3SIBySAuBlK4ZyA6xaw2FCXnjHk9CSXAaY+mzK03DeiDAB4qMvMwpyMdE3TJEqwP//D8ZPTnQ49sG5a5oBg=="
 		},
 		"@discordjs/formatters": {
-			"version": "0.4.0-dev.1710979856-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0-dev.1710979856-6cc5fa28e.tgz",
-			"integrity": "sha512-ZKZitLtmJq/SemqB3UKRkzvYlK1xXzT4awuilqaf/FigbZQGL6m51ESafijbUNtUHc1+GKeK2Nzxc2BxpyvCqQ==",
+			"version": "0.4.0-dev.1711325408-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.0-dev.1711325408-a1a3a95c9.tgz",
+			"integrity": "sha512-lZkX5D/oKBlsCZuHDPLPwWEXeMox229OlKRzBZEjKjf7cWq89qZw9R2L8IA82ZaaU6f8wgjH59gKSFubF2c/Kg==",
 			"requires": {
 				"discord-api-types": "0.37.61"
 			}
 		},
 		"@discordjs/rest": {
-			"version": "2.3.0-dev.1710979855-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1710979855-6cc5fa28e.tgz",
-			"integrity": "sha512-9xpO1Tl+FxyaIWA9d6/nyq/b4LW+cmufd537XjG0bcMkVYJ8I+4+NjEq53wGfuMmkvITShbxS1EHBrUleSR85g==",
+			"version": "2.3.0-dev.1711325406-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.0-dev.1711325406-a1a3a95c9.tgz",
+			"integrity": "sha512-2zzb/1Zrw7gw8KKOf2XcSGQ2IF22kt2VhUdnTRTtDqUkrR8DSiIMuQGU+JckndIMC5LXZmdfWxwbeCHelzPfdQ==",
 			"requires": {
 				"@discordjs/collection": "dev",
 				"@discordjs/util": "dev",
@@ -5131,14 +5344,14 @@
 			}
 		},
 		"@discordjs/util": {
-			"version": "1.1.0-dev.1710979853-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1710979853-6cc5fa28e.tgz",
-			"integrity": "sha512-KTSsP/NoluN8kcYzIpyDmaNACqFwjnVtDPC0jcKQuZKAPrA1TtsYf/3ig/h1/yVRyoF6bb+uxqx1F6XnKdK0WQ=="
+			"version": "1.1.0-dev.1711325410-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.0-dev.1711325410-a1a3a95c9.tgz",
+			"integrity": "sha512-kT+GULg3dBlmv28H39BiHAdkaXdx9Je0JKgI/K1w+qm2z0ODPdVo6es/m23v7yBDlW4GxV3zwZnE5hkzkZqVkw=="
 		},
 		"@discordjs/ws": {
-			"version": "1.1.0-dev.1710979857-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1710979857-6cc5fa28e.tgz",
-			"integrity": "sha512-G1bl/bSCx/YXEuA/7VLBl9mqAjME4DPNroUWF+eNUDHjRyopZC0Kiy1Zxg+uNqRWtdC47cXaIOjHAwisoaHCeA==",
+			"version": "1.1.0-dev.1711325409-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.0-dev.1711325409-a1a3a95c9.tgz",
+			"integrity": "sha512-lulTCPr0SUv11KMeY4UuZCk5j+whI9gLMrMoFz1L8Qj3Dmyk8LNZAGKlv8uer89n75Qus6dH50FlIN+uCcUTFQ==",
 			"requires": {
 				"@discordjs/collection": "dev",
 				"@discordjs/rest": "dev",
@@ -5356,6 +5569,12 @@
 			"integrity": "sha512-n+sgQ6hr1hgxAFIozUhgSlsswFxOl51HNuMAz1EA9M+jh6yIMopO+6RV55j6yYX0Vxkqbj9wkkaEIC3uQisGAg==",
 			"optional": true
 		},
+		"@napi-rs/triples": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.2.0.tgz",
+			"integrity": "sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==",
+			"optional": true
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5380,6 +5599,17 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@railway/cli": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@railway/cli/-/cli-3.5.2.tgz",
+			"integrity": "sha512-N1F1RMP8RaiNBS0qBfbc1wBROyz4jD9LRyQRHEZTz4Xlg4Rj7O3yyMi36oROfVxk50MGEDKK8Bx/GR3qBUWE1A==",
+			"optional": true,
+			"requires": {
+				"@napi-rs/triples": "^1.1.0",
+				"node-fetch": "^3.1.0",
+				"tar": "^6.1.11"
 			}
 		},
 		"@redguy12/prettier-config": {
@@ -6673,6 +6903,12 @@
 				}
 			}
 		},
+		"chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"optional": true
+		},
 		"ci-info": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
@@ -6737,6 +6973,12 @@
 				"which": "^2.0.1"
 			}
 		},
+		"data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"optional": true
+		},
 		"debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -6784,9 +7026,9 @@
 			"integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
 		},
 		"discord.js": {
-			"version": "14.15.0-dev.1710979853-6cc5fa28e",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1710979853-6cc5fa28e.tgz",
-			"integrity": "sha512-naS+xioFRz6qMZWo0Cy9M6FqjDL0M945OWzQvCfCxY0aIMSMUQMoCAwFjK04obDOXqKrJjj++BW5+TKU85vY5g==",
+			"version": "14.15.0-dev.1711325411-a1a3a95c9",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.0-dev.1711325411-a1a3a95c9.tgz",
+			"integrity": "sha512-ntaGCvmGCSwlNS1YB94OI5Wxjrj5zWDde/+hdYB04eTxFjdTs0nUZV7ocKKk+/qyYm2C/UY3hRaO/Qh/QcmCTw==",
 			"requires": {
 				"@discordjs/builders": "dev",
 				"@discordjs/collection": "dev",
@@ -7081,6 +7323,16 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"optional": true,
+			"requires": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			}
+		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7125,6 +7377,35 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
 			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
 			"dev": true
+		},
+		"formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"optional": true,
+			"requires": {
+				"fetch-blob": "^3.1.2"
+			}
+		},
+		"fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"optional": true,
+			"requires": {
+				"minipass": "^3.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"optional": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
+			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -7558,6 +7839,39 @@
 				"brace-expansion": "^2.0.1"
 			}
 		},
+		"minipass": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"optional": true
+		},
+		"minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"optional": true,
+			"requires": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"minipass": {
+					"version": "3.3.6",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+					"optional": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"optional": true
+		},
 		"mongodb": {
 			"version": "5.9.0",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
@@ -7627,6 +7941,23 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"optional": true
+		},
+		"node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"optional": true,
+			"requires": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			}
 		},
 		"node-releases": {
 			"version": "2.0.14",
@@ -8262,6 +8593,20 @@
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true
 		},
+		"tar": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"optional": true,
+			"requires": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8377,6 +8722,12 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
+		"web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"optional": true
+		},
 		"webidl-conversions": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -8416,7 +8767,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"devOptional": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/builders@1.8.0-dev.1710979856-6cc5fa28e`](https://npmjs.com/package/@discordjs/builders/v/1.8.0-dev.1710979856-6cc5fa28e) to [`1.8.0-dev.1711325431-a1a3a95c9`](https://npmjs.com/package/@discordjs/builders/v/1.8.0-dev.1711325431-a1a3a95c9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/builders))
- Bumped [`@discordjs/collection@2.1.0-dev.1710979855-6cc5fa28e`](https://npmjs.com/package/@discordjs/collection/v/2.1.0-dev.1710979855-6cc5fa28e) to [`2.1.0-dev.1711325413-a1a3a95c9`](https://npmjs.com/package/@discordjs/collection/v/2.1.0-dev.1711325413-a1a3a95c9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/collection))
- Bumped [`@discordjs/formatters@0.4.0-dev.1710979856-6cc5fa28e`](https://npmjs.com/package/@discordjs/formatters/v/0.4.0-dev.1710979856-6cc5fa28e) to [`0.4.0-dev.1711325408-a1a3a95c9`](https://npmjs.com/package/@discordjs/formatters/v/0.4.0-dev.1711325408-a1a3a95c9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.3.0-dev.1710979855-6cc5fa28e`](https://npmjs.com/package/@discordjs/rest/v/2.3.0-dev.1710979855-6cc5fa28e) to [`2.3.0-dev.1711325406-a1a3a95c9`](https://npmjs.com/package/@discordjs/rest/v/2.3.0-dev.1711325406-a1a3a95c9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.0-dev.1710979853-6cc5fa28e`](https://npmjs.com/package/@discordjs/util/v/1.1.0-dev.1710979853-6cc5fa28e) to [`1.1.0-dev.1711325410-a1a3a95c9`](https://npmjs.com/package/@discordjs/util/v/1.1.0-dev.1711325410-a1a3a95c9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@discordjs/ws@1.1.0-dev.1710979857-6cc5fa28e`](https://npmjs.com/package/@discordjs/ws/v/1.1.0-dev.1710979857-6cc5fa28e) to [`1.1.0-dev.1711325409-a1a3a95c9`](https://npmjs.com/package/@discordjs/ws/v/1.1.0-dev.1711325409-a1a3a95c9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/ws))
- Installed [`@napi-rs/triples@1.2.0`](https://npmjs.com/package/@napi-rs/triples/v/1.2.0)
- Installed [`@railway/cli@3.5.2`](https://npmjs.com/package/@railway/cli/v/3.5.2)
- Installed [`chownr@2.0.0`](https://npmjs.com/package/chownr/v/2.0.0)
- Installed [`data-uri-to-buffer@4.0.1`](https://npmjs.com/package/data-uri-to-buffer/v/4.0.1)
- Bumped [`discord.js@14.15.0-dev.1710979853-6cc5fa28e`](https://npmjs.com/package/discord.js/v/14.15.0-dev.1710979853-6cc5fa28e) to [`14.15.0-dev.1711325411-a1a3a95c9`](https://npmjs.com/package/discord.js/v/14.15.0-dev.1711325411-a1a3a95c9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/discord.js))
- Installed [`fetch-blob@3.2.0`](https://npmjs.com/package/fetch-blob/v/3.2.0)
- Installed [`formdata-polyfill@4.0.10`](https://npmjs.com/package/formdata-polyfill/v/4.0.10)
- Installed [`fs-minipass@2.1.0`](https://npmjs.com/package/fs-minipass/v/2.1.0)
- Installed [`minipass@3.3.6`](https://npmjs.com/package/minipass/v/3.3.6)
- Installed [`minipass@5.0.0`](https://npmjs.com/package/minipass/v/5.0.0)
- Installed [`minizlib@2.1.2`](https://npmjs.com/package/minizlib/v/2.1.2)
- Installed [`mkdirp@1.0.4`](https://npmjs.com/package/mkdirp/v/1.0.4)
- Installed [`node-domexception@1.0.0`](https://npmjs.com/package/node-domexception/v/1.0.0)
- Installed [`node-fetch@3.3.2`](https://npmjs.com/package/node-fetch/v/3.3.2)
- Installed [`tar@6.2.1`](https://npmjs.com/package/tar/v/6.2.1)
- Installed [`web-streams-polyfill@3.3.3`](https://npmjs.com/package/web-streams-polyfill/v/3.3.3)
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
