### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2861,9 +2861,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.715",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
-			"integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==",
+			"version": "1.4.717",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
+			"integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -7089,9 +7089,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.715",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
-			"integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==",
+			"version": "1.4.717",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
+			"integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==",
 			"dev": true
 		},
 		"entities": {


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`electron-to-chromium@1.4.715`](https://npmjs.com/package/electron-to-chromium/v/1.4.715) to [`1.4.717`](https://npmjs.com/package/electron-to-chromium/v/1.4.717) ([see recent commits](https://github.com/kilian/electron-to-chromium))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
