### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2880,9 +2880,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.717",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
-			"integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==",
+			"version": "1.4.719",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.719.tgz",
+			"integrity": "sha512-FbWy2Q2YgdFzkFUW/W5jBjE9dj+804+98E4Pup78JBPnbdb3pv6IneY2JCPKdeKLh3AOKHQeYf+KwLr7mxGh6Q==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -7094,9 +7094,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.717",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
-			"integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==",
+			"version": "1.4.719",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.719.tgz",
+			"integrity": "sha512-FbWy2Q2YgdFzkFUW/W5jBjE9dj+804+98E4Pup78JBPnbdb3pv6IneY2JCPKdeKLh3AOKHQeYf+KwLr7mxGh6Q==",
 			"dev": true
 		},
 		"entities": {


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`electron-to-chromium@1.4.717`](https://npmjs.com/package/electron-to-chromium/v/1.4.717) to [`1.4.719`](https://npmjs.com/package/electron-to-chromium/v/1.4.719) ([see recent commits](https://github.com/kilian/electron-to-chromium))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
