### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "scradd",
-			"version": "2.9.6",
+			"version": "3.0.0",
 			"dependencies": {
 				"@fontsource-variable/sora": "5.0.17",
 				"@khanacademy/simple-markdown": "0.11.4",
@@ -2880,9 +2880,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.719",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.719.tgz",
-			"integrity": "sha512-FbWy2Q2YgdFzkFUW/W5jBjE9dj+804+98E4Pup78JBPnbdb3pv6IneY2JCPKdeKLh3AOKHQeYf+KwLr7mxGh6Q==",
+			"version": "1.4.720",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.720.tgz",
+			"integrity": "sha512-5zwcKNkOj3GN0jBzpcpGonNPkn667VJpQwRYWdo/TiJEHTQswZyA/vALhZFiAXgL5NuK9UarX1tbdvXu3hG6Yw==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -7094,9 +7094,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.719",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.719.tgz",
-			"integrity": "sha512-FbWy2Q2YgdFzkFUW/W5jBjE9dj+804+98E4Pup78JBPnbdb3pv6IneY2JCPKdeKLh3AOKHQeYf+KwLr7mxGh6Q==",
+			"version": "1.4.720",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.720.tgz",
+			"integrity": "sha512-5zwcKNkOj3GN0jBzpcpGonNPkn667VJpQwRYWdo/TiJEHTQswZyA/vALhZFiAXgL5NuK9UarX1tbdvXu3hG6Yw==",
 			"dev": true
 		},
 		"entities": {


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`scradd@2.9.6`](https://npmjs.com/package/scradd/v/2.9.6) to [`3.0.0`](https://npmjs.com/package/scradd/v/3.0.0)
- Bumped [`electron-to-chromium@1.4.719`](https://npmjs.com/package/electron-to-chromium/v/1.4.719) to [`1.4.720`](https://npmjs.com/package/electron-to-chromium/v/1.4.720) ([see recent commits](https://github.com/kilian/electron-to-chromium))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
