### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2880,9 +2880,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.720",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.720.tgz",
-			"integrity": "sha512-5zwcKNkOj3GN0jBzpcpGonNPkn667VJpQwRYWdo/TiJEHTQswZyA/vALhZFiAXgL5NuK9UarX1tbdvXu3hG6Yw==",
+			"version": "1.4.721",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.721.tgz",
+			"integrity": "sha512-k1x2r6foI8iJOp+1qTxbbrrWMsOiHkzGBYwYigaq+apO1FSqtn44KTo3Sy69qt7CRr7149zTcsDvH7MUKsOuIQ==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -7094,9 +7094,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.720",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.720.tgz",
-			"integrity": "sha512-5zwcKNkOj3GN0jBzpcpGonNPkn667VJpQwRYWdo/TiJEHTQswZyA/vALhZFiAXgL5NuK9UarX1tbdvXu3hG6Yw==",
+			"version": "1.4.721",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.721.tgz",
+			"integrity": "sha512-k1x2r6foI8iJOp+1qTxbbrrWMsOiHkzGBYwYigaq+apO1FSqtn44KTo3Sy69qt7CRr7149zTcsDvH7MUKsOuIQ==",
 			"dev": true
 		},
 		"entities": {


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`electron-to-chromium@1.4.720`](https://npmjs.com/package/electron-to-chromium/v/1.4.720) to [`1.4.721`](https://npmjs.com/package/electron-to-chromium/v/1.4.721) ([see recent commits](https://github.com/kilian/electron-to-chromium))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
