### PR TITLE
potentially fix qotd pagination

### DIFF
--- a/modules/polls/qotd.ts
+++ b/modules/polls/qotd.ts
@@ -188,10 +188,11 @@ export async function addQuestion(interaction: ChatInputCommandInteraction): Pro
 }
 
 export async function listQuestions(interaction: ChatInputCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
 	await paginate(
 		questions,
 		({ question }) => question ?? "",
-		(data) => interaction.reply(data),
+		(data) => interaction.editReply(data),
 		{
 			title: "Upcoming QOTDs",
 			singular: "QOTD",


### PR DESCRIPTION
attempts to avoid errors like https://discord.com/channels/806602307750985799/1020590613915242548/1225798138800111618 by using a similar approach to xp-top (defer response, then edit). untested but I don't see why it wouldn't work.