### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.8.2-dev.1714954193-776880d06",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2-dev.1714954193-776880d06.tgz",
-			"integrity": "sha512-dOEJBQtJQLJOB9nbtiYcdOJLvlBxvNLKZdEmB8jKqPF+52wRKaEZlTiiLbJ6RsS8nTKxxmUYEuwZhtqbRKY8Vw==",
+			"version": "1.8.2-dev.1716120217-b36ec9838",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2-dev.1716120217-b36ec9838.tgz",
+			"integrity": "sha512-IhqvGpxnHR/cpIG1WXfZK+O/MglbMoEwk8pU4REKngZg41x73QfN69lZgHilT5Tl79Co4KNMRXQ9ClqKahaJ6Q==",
 			"dependencies": {
 				"@discordjs/formatters": "^0.4.0",
 				"@discordjs/util": "^1.1.0",
@@ -197,9 +197,9 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.4.1-dev.1714954187-776880d06",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.1-dev.1714954187-776880d06.tgz",
-			"integrity": "sha512-fWkb5xt6T/njRRfamCYAwLrIKw3OjlvAQrwqowHgrG7HImpfVDTqx/Q+iXJL7vZRyAdqpZK9OB26PJruVen6dw==",
+			"version": "0.4.1-dev.1716120229-b36ec9838",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.1-dev.1716120229-b36ec9838.tgz",
+			"integrity": "sha512-19CPh4/9Vu852qmqD7KQw/SpAc4/nsZNQv2Sca0SmUMgKQQGOlMgKiEp1dPX+j47kY6s22NBCLlKDrpT5DSWMA==",
 			"dependencies": {
 				"discord-api-types": "0.37.83"
 			},
@@ -211,9 +211,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.3.1-dev.1714954186-776880d06",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.1-dev.1714954186-776880d06.tgz",
-			"integrity": "sha512-XVUhRue8XMBN6xhPPzzg9xRcHxI+7lt2HHjADI8Cj5O5BMwObnAOirR27XWTlvFuBUwNHAXyudPn22cql7qUeg==",
+			"version": "2.3.1-dev.1716120225-b36ec9838",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.1-dev.1716120225-b36ec9838.tgz",
+			"integrity": "sha512-dPHUK2vRRb76kJ04PnkW+jGP5MoOx55vBLcV/5EDOe0k8h84fwbS/g0mjg5FCgD6KRiJfTay9rq2Ogh7ZtwgfA==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/util": "^1.1.0",
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.1-dev.1714954185-776880d06",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1714954185-776880d06.tgz",
-			"integrity": "sha512-kHdox9HfU5JdH3bIcaPlH0UCga01imw6Obnk6ykjkw7RWcwz7fhNJmnRRDdozbw40+/PvzAoXZSYVgwVDa0s1w==",
+			"version": "1.1.1-dev.1716120216-b36ec9838",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1716120216-b36ec9838.tgz",
+			"integrity": "sha512-JXR/9oU5pTQVtFujebnaAG1tmhjOD3QMXfpKx9g2pkc1ctqAbK9IgGd3RD8Ji1ucyEJvlHJvXlpINpztLWPAfQ==",
 			"engines": {
 				"node": ">=16.11.0"
 			},
@@ -244,9 +244,9 @@
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "1.1.1-dev.1714954189-776880d06",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1-dev.1714954189-776880d06.tgz",
-			"integrity": "sha512-ZYdkRP4QMtI0Ye5Oi5NJJRM5U1vwUbIDdOPEWF/AQMrH8R4VNvmZxCt70jo5hRXYL8Vo0ZVMZ0g6HJsUuKgFVQ==",
+			"version": "2.0.0-dev.1716120228-b36ec9838",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-2.0.0-dev.1716120228-b36ec9838.tgz",
+			"integrity": "sha512-fxZuvYEfRGWdUkMOdjdR/OJLYQfIIXgvjNPWCKM3aJ/Ah/mR+K7xpRn0AwYvm6nxfP63B2ygQIBR0J+fJ2X2YA==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/rest": "^2.3.0",
@@ -427,9 +427,9 @@
 			"optional": true
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.6.tgz",
-			"integrity": "sha512-jqTTXQ46H8cAxmXBu8wm1HTSIMBMrIcoVrsjdQkKdMBj3il/fSCgWyya4P2I1xjPBl69mw+nRphrPlcIqBd20Q==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.7.tgz",
+			"integrity": "sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==",
 			"optional": true,
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
@@ -1894,9 +1894,9 @@
 			}
 		},
 		"node_modules/@sapphire/snowflake": {
-			"version": "3.5.4-next.c6490032.0",
-			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.4-next.c6490032.0.tgz",
-			"integrity": "sha512-n+GSjONFQtNOZSs+XoqSpYdlVMi9tMMovIuhO5Z8tbAlSvHfxhh0IwAjEykTFbqFWP1k6HsXqmaABgkz6zzcxg==",
+			"version": "3.5.4-next.9ef6dfd8.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.4-next.9ef6dfd8.0.tgz",
+			"integrity": "sha512-o1SH9HlVFsue8qoULIuaIE59MWzYfhDXLBJ7qSl0sZEAi7Mb5QV2uA3rLLAmRjID1yRbVger08B2A3/hI3eJ6Q==",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -2064,47 +2064,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
-			"integrity": "sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz",
-			"integrity": "sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "7.10.0",
-				"@typescript-eslint/visitor-keys": "7.10.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^1.3.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
 			"version": "7.10.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz",
@@ -2131,6 +2090,19 @@
 				"@typescript-eslint/types": "7.9.0",
 				"@typescript-eslint/visitor-keys": "7.9.0"
 			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.9.0.tgz",
+			"integrity": "sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==",
+			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
 			},
@@ -2166,7 +2138,7 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.9.0.tgz",
 			"integrity": "sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==",
@@ -2179,7 +2151,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.9.0.tgz",
 			"integrity": "sha512-zBCMCkrb2YjpKV3LA0ZJubtKCDxLttxfdGmwZvTqqWevUPN0FZvSI26FalGFFUZU/9YQK/A4xcQF9o/VVaCKAg==",
@@ -2207,6 +2179,64 @@
 				}
 			}
 		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.10.0.tgz",
+			"integrity": "sha512-7fNj+Ya35aNyhuqrA1E/VayQX9Elwr8NKZ4WueClR3KwJ7Xx9jcCdOrLW04h51de/+gNbyFMs+IDxh5xIwfbNg==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.10.0.tgz",
+			"integrity": "sha512-LXFnQJjL9XIcxeVfqmNj60YhatpRLt6UhdlFwAkjNc6jSUlK8zQOl1oktAP8PlWFzPQC1jny/8Bai3/HPuvN5g==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "7.10.0",
+				"@typescript-eslint/visitor-keys": "7.10.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.10.0.tgz",
+			"integrity": "sha512-9ntIVgsi6gg6FIq9xjEO4VQJvwOqA3jaBFQJ/6TK5AvEup2+cECI6Fh7QiBxmfMHXU0V0J4RyPeOU1VDNzl9cg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "7.10.0",
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.9.0.tgz",
@@ -2229,6 +2259,47 @@
 				"eslint": "^8.56.0"
 			}
 		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.9.0.tgz",
+			"integrity": "sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.9.0.tgz",
+			"integrity": "sha512-zBCMCkrb2YjpKV3LA0ZJubtKCDxLttxfdGmwZvTqqWevUPN0FZvSI26FalGFFUZU/9YQK/A4xcQF9o/VVaCKAg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "7.9.0",
+				"@typescript-eslint/visitor-keys": "7.9.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.9.0.tgz",
@@ -2238,6 +2309,19 @@
 				"@typescript-eslint/types": "7.9.0",
 				"eslint-visitor-keys": "^3.4.3"
 			},
+			"engines": {
+				"node": "^18.18.0 || >=20.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.9.0.tgz",
+			"integrity": "sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==",
+			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
 			},
@@ -2260,12 +2344,6 @@
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
 			}
-		},
-		"node_modules/abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
 		},
 		"node_modules/acorn": {
 			"version": "8.11.3",
@@ -2384,12 +2462,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2457,9 +2535,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001616",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001616.tgz",
-			"integrity": "sha512-RHVYKov7IcdNjVHJFNY/78RdG4oGVjbayxv8u5IO74Wv7Hlq4PnJE6mo/OjFijjVFNy5ijnCt6H3IIo4t+wfEw==",
+			"version": "1.0.30001621",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
+			"integrity": "sha512-+NLXZiviFFKX0fk8Piwv3PfLPGtRqJeq2TiNoUff/qB5KJgwecJTvCXDpmlyP/eCI/GUEmp/h/y5j0yckiiZrA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2610,9 +2688,9 @@
 			"dev": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.37.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
-			"integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
+			"version": "3.37.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
+			"integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.23.0"
@@ -2708,9 +2786,9 @@
 			"integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
 		},
 		"node_modules/discord.js": {
-			"version": "14.15.3-dev.1714954188-776880d06",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3-dev.1714954188-776880d06.tgz",
-			"integrity": "sha512-SZ8jpTXC8+nzpJTYjB34O+koNxYGG3lG4zEj7P9+m87bqu9FPtGD71BGNuz0QBaOghncBKGyoYpccByeG8Dq/g==",
+			"version": "14.15.3-dev.1716120217-b36ec9838",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3-dev.1716120217-b36ec9838.tgz",
+			"integrity": "sha512-asyDEgm/ME/Rf63c3oFIw5vFI8+5wwFOuu+F3qGe3QZw5780kY8WJpow4OdR8BGBLrpcTj1Ln4Wys2B06NDi2Q==",
 			"dependencies": {
 				"@discordjs/builders": "^1.8.1",
 				"@discordjs/collection": "1.5.3",
@@ -2796,9 +2874,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.757",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.757.tgz",
-			"integrity": "sha512-jftDaCknYSSt/+KKeXzH3LX5E2CvRLm75P3Hj+J/dv3CL0qUYcOt13d5FN1NiL5IJbbhzHrb3BomeG2tkSlZmw==",
+			"version": "1.4.779",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.779.tgz",
+			"integrity": "sha512-oaTiIcszNfySXVJzKcjxd2YjPxziAd+GmXyb2HbidCeFo6Z88ygOT7EimlrEQhM2U08VhSrbKhLOXP0kKUCZ6g==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -3137,9 +3215,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -3447,6 +3525,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
@@ -3703,18 +3782,6 @@
 				"loose-envify": "cli.js"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/magic-bytes.js": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
@@ -3745,12 +3812,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+			"integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -4054,21 +4121,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/nopt": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-			"integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-			"dev": true,
-			"dependencies": {
-				"abbrev": "1"
-			},
-			"bin": {
-				"nopt": "bin/nopt.js"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -4251,9 +4303,9 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
 			"dev": true
 		},
 		"node_modules/picomatch": {
@@ -4631,13 +4683,10 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4896,13 +4945,10 @@
 			}
 		},
 		"node_modules/touch": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-			"integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+			"integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
 			"dev": true,
-			"dependencies": {
-				"nopt": "~1.0.10"
-			},
 			"bin": {
 				"nodetouch": "bin/nodetouch.js"
 			}
@@ -4997,9 +5043,9 @@
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.15",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
-			"integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+			"integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5017,7 +5063,7 @@
 			],
 			"dependencies": {
 				"escalade": "^3.1.2",
-				"picocolors": "^1.0.0"
+				"picocolors": "^1.0.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -5128,7 +5174,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"devOptional": true
+			"optional": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/builders@1.8.2-dev.1714954193-776880d06`](https://npmjs.com/package/@discordjs/builders/v/1.8.2-dev.1714954193-776880d06) to [`1.8.2-dev.1716120217-b36ec9838`](https://npmjs.com/package/@discordjs/builders/v/1.8.2-dev.1716120217-b36ec9838) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/builders))
- Bumped [`@discordjs/formatters@0.4.1-dev.1714954187-776880d06`](https://npmjs.com/package/@discordjs/formatters/v/0.4.1-dev.1714954187-776880d06) to [`0.4.1-dev.1716120229-b36ec9838`](https://npmjs.com/package/@discordjs/formatters/v/0.4.1-dev.1716120229-b36ec9838) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.3.1-dev.1714954186-776880d06`](https://npmjs.com/package/@discordjs/rest/v/2.3.1-dev.1714954186-776880d06) to [`2.3.1-dev.1716120225-b36ec9838`](https://npmjs.com/package/@discordjs/rest/v/2.3.1-dev.1716120225-b36ec9838) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.1-dev.1714954185-776880d06`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1714954185-776880d06) to [`1.1.1-dev.1716120216-b36ec9838`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1716120216-b36ec9838) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@discordjs/ws@1.1.1-dev.1714954189-776880d06`](https://npmjs.com/package/@discordjs/ws/v/1.1.1-dev.1714954189-776880d06) to [`2.0.0-dev.1716120228-b36ec9838`](https://npmjs.com/package/@discordjs/ws/v/2.0.0-dev.1716120228-b36ec9838) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/ws))
- Bumped [`@mongodb-js/saslprep@1.1.6`](https://npmjs.com/package/@mongodb-js/saslprep/v/1.1.6) to [`1.1.7`](https://npmjs.com/package/@mongodb-js/saslprep/v/1.1.7) ([see recent commits](https://github.com/mongodb-js/devtools-shared))
- Bumped [`@sapphire/snowflake@3.5.4-next.c6490032.0`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.4-next.c6490032.0) to [`3.5.4-next.9ef6dfd8.0`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.4-next.9ef6dfd8.0) ([see recent commits](https://github.com/sapphiredev/utilities/commits/HEAD/packages/snowflake))
- Installed [`@typescript-eslint/types@7.9.0`](https://npmjs.com/package/@typescript-eslint/types/v/7.9.0)
- Installed [`@typescript-eslint/typescript-estree@7.9.0`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.9.0)
- Bumped [`@typescript-eslint/types@7.9.0`](https://npmjs.com/package/@typescript-eslint/types/v/7.9.0) to [`7.10.0`](https://npmjs.com/package/@typescript-eslint/types/v/7.10.0) ([see recent commits](https://github.com/typescript-eslint/typescript-eslint/commits/HEAD/packages/types))
- Bumped [`@typescript-eslint/typescript-estree@7.9.0`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.9.0) to [`7.10.0`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.10.0) ([see recent commits](https://github.com/typescript-eslint/typescript-eslint/commits/HEAD/packages/typescript-estree))
- Installed [`@typescript-eslint/visitor-keys@7.10.0`](https://npmjs.com/package/@typescript-eslint/visitor-keys/v/7.10.0)
- Bumped [`braces@3.0.2`](https://npmjs.com/package/braces/v/3.0.2) to [`3.0.3`](https://npmjs.com/package/braces/v/3.0.3) ([see recent commits](https://github.com/micromatch/braces))
- Bumped [`caniuse-lite@1.0.30001616`](https://npmjs.com/package/caniuse-lite/v/1.0.30001616) to [`1.0.30001621`](https://npmjs.com/package/caniuse-lite/v/1.0.30001621) ([see recent commits](https://github.com/browserslist/caniuse-lite))
- Bumped [`core-js-compat@3.37.0`](https://npmjs.com/package/core-js-compat/v/3.37.0) to [`3.37.1`](https://npmjs.com/package/core-js-compat/v/3.37.1) ([see recent commits](https://github.com/zloirock/core-js/commits/HEAD/packages/core-js-compat))
- Bumped [`discord.js@14.15.3-dev.1714954188-776880d06`](https://npmjs.com/package/discord.js/v/14.15.3-dev.1714954188-776880d06) to [`14.15.3-dev.1716120217-b36ec9838`](https://npmjs.com/package/discord.js/v/14.15.3-dev.1716120217-b36ec9838) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/discord.js))
- Bumped [`electron-to-chromium@1.4.757`](https://npmjs.com/package/electron-to-chromium/v/1.4.757) to [`1.4.779`](https://npmjs.com/package/electron-to-chromium/v/1.4.779) ([see recent commits](https://github.com/kilian/electron-to-chromium))
- Bumped [`fill-range@7.0.1`](https://npmjs.com/package/fill-range/v/7.0.1) to [`7.1.1`](https://npmjs.com/package/fill-range/v/7.1.1) ([see recent commits](https://github.com/jonschlinkert/fill-range))
- Bumped [`micromatch@4.0.5`](https://npmjs.com/package/micromatch/v/4.0.5) to [`4.0.7`](https://npmjs.com/package/micromatch/v/4.0.7) ([see recent commits](https://github.com/micromatch/micromatch))
- Bumped [`picocolors@1.0.0`](https://npmjs.com/package/picocolors/v/1.0.0) to [`1.0.1`](https://npmjs.com/package/picocolors/v/1.0.1) ([see recent commits](https://github.com/alexeyraspopov/picocolors))
- Bumped [`semver@7.6.0`](https://npmjs.com/package/semver/v/7.6.0) to [`7.6.2`](https://npmjs.com/package/semver/v/7.6.2) ([see recent commits](https://github.com/npm/node-semver))
- Bumped [`touch@3.1.0`](https://npmjs.com/package/touch/v/3.1.0) to [`3.1.1`](https://npmjs.com/package/touch/v/3.1.1) ([see recent commits](https://github.com/isaacs/node-touch))
- Bumped [`update-browserslist-db@1.0.15`](https://npmjs.com/package/update-browserslist-db/v/1.0.15) to [`1.0.16`](https://npmjs.com/package/update-browserslist-db/v/1.0.16) ([see recent commits](https://github.com/browserslist/update-db))
- Removed [`@typescript-eslint/types@7.10.0`](https://npmjs.com/package/@typescript-eslint/types/v/7.10.0)
- Removed [`@typescript-eslint/typescript-estree@7.10.0`](https://npmjs.com/package/@typescript-eslint/typescript-estree/v/7.10.0)
- Removed [`abbrev@1.1.1`](https://npmjs.com/package/abbrev/v/1.1.1)
- Removed [`lru-cache@6.0.0`](https://npmjs.com/package/lru-cache/v/6.0.0)
- Removed [`nopt@1.0.10`](https://npmjs.com/package/nopt/v/1.0.10)
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
