### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,12 +49,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.24.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz",
+			"integrity": "sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.24.2",
+				"@babel/highlight": "^7.24.6",
 				"picocolors": "^1.0.0"
 			},
 			"engines": {
@@ -62,21 +62,21 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
-			"integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
+			"integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
-			"integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz",
+			"integrity": "sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.24.5",
+				"@babel/helper-validator-identifier": "^7.24.6",
 				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.0.0"
@@ -157,9 +157,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-			"integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
+			"integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -168,9 +168,9 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.8.2-dev.1716120217-b36ec9838",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2-dev.1716120217-b36ec9838.tgz",
-			"integrity": "sha512-IhqvGpxnHR/cpIG1WXfZK+O/MglbMoEwk8pU4REKngZg41x73QfN69lZgHilT5Tl79Co4KNMRXQ9ClqKahaJ6Q==",
+			"version": "1.8.2-dev.1716595776-a468ae8bb",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2-dev.1716595776-a468ae8bb.tgz",
+			"integrity": "sha512-q+eVB/qFVkRjVHpokBc5ZStbcOffMYwwsefjA6n9Wt+q38jkGdhHdL6u68PpqO0U6bjVTQXz5MAiD+XwwUwH0Q==",
 			"dependencies": {
 				"@discordjs/formatters": "^0.4.0",
 				"@discordjs/util": "^1.1.0",
@@ -197,9 +197,9 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.4.1-dev.1716120229-b36ec9838",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.1-dev.1716120229-b36ec9838.tgz",
-			"integrity": "sha512-19CPh4/9Vu852qmqD7KQw/SpAc4/nsZNQv2Sca0SmUMgKQQGOlMgKiEp1dPX+j47kY6s22NBCLlKDrpT5DSWMA==",
+			"version": "0.4.1-dev.1716595779-a468ae8bb",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.1-dev.1716595779-a468ae8bb.tgz",
+			"integrity": "sha512-dQ42y5BSh4g3EGvyo77IXGKAycCTV9WWnEzO96j0OIA0TtV7I+zrqQWR1eO6QnCaOiWqvF5vMEG212vakbUcOQ==",
 			"dependencies": {
 				"discord-api-types": "0.37.83"
 			},
@@ -211,9 +211,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.3.1-dev.1716120225-b36ec9838",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.1-dev.1716120225-b36ec9838.tgz",
-			"integrity": "sha512-dPHUK2vRRb76kJ04PnkW+jGP5MoOx55vBLcV/5EDOe0k8h84fwbS/g0mjg5FCgD6KRiJfTay9rq2Ogh7ZtwgfA==",
+			"version": "2.3.1-dev.1716595785-a468ae8bb",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.1-dev.1716595785-a468ae8bb.tgz",
+			"integrity": "sha512-kz1PUypMoYvMtdG6NlD7ctV/nTT/RORx0YVUCdEM5DAvxhsZxQe2TBOFtsb52u/xelKDRDFEqJn27PIzujuGyg==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/util": "^1.1.0",
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.1-dev.1716120216-b36ec9838",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1716120216-b36ec9838.tgz",
-			"integrity": "sha512-JXR/9oU5pTQVtFujebnaAG1tmhjOD3QMXfpKx9g2pkc1ctqAbK9IgGd3RD8Ji1ucyEJvlHJvXlpINpztLWPAfQ==",
+			"version": "1.1.1-dev.1716595772-a468ae8bb",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1716595772-a468ae8bb.tgz",
+			"integrity": "sha512-F3Gh5h6gI+Qn8h7z0QBoH6f5jmCStMqdZMLGbtsw3jr2lSkheRA9GQl/KKcApNf2/g/iCfy9T9KU2F7oN87pMQ==",
 			"engines": {
 				"node": ">=16.11.0"
 			},
@@ -244,9 +244,9 @@
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "2.0.0-dev.1716120228-b36ec9838",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-2.0.0-dev.1716120228-b36ec9838.tgz",
-			"integrity": "sha512-fxZuvYEfRGWdUkMOdjdR/OJLYQfIIXgvjNPWCKM3aJ/Ah/mR+K7xpRn0AwYvm6nxfP63B2ygQIBR0J+fJ2X2YA==",
+			"version": "2.0.0-dev.1716595774-a468ae8bb",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-2.0.0-dev.1716595774-a468ae8bb.tgz",
+			"integrity": "sha512-w/4jl+W7R2dbQq9bYZNFXCeTw+OdB8UO1vkGBdWLX4u/9r1oMc/sMW/G/WhCoEuno24sXTrQ59QmKlFfjklGNg==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/rest": "^2.3.0",
@@ -2786,9 +2786,9 @@
 			"integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
 		},
 		"node_modules/discord.js": {
-			"version": "14.15.3-dev.1716120217-b36ec9838",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3-dev.1716120217-b36ec9838.tgz",
-			"integrity": "sha512-asyDEgm/ME/Rf63c3oFIw5vFI8+5wwFOuu+F3qGe3QZw5780kY8WJpow4OdR8BGBLrpcTj1Ln4Wys2B06NDi2Q==",
+			"version": "14.15.3-dev.1716595781-a468ae8bb",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3-dev.1716595781-a468ae8bb.tgz",
+			"integrity": "sha512-Q5V8uObdwJLsmaDbmMoIdhUfJE9YAAOFhy+turJyfGkjRDvd4if4KSJRWrpuf45QqT8vzaSGI8VrbS0wEDTkBg==",
 			"dependencies": {
 				"@discordjs/builders": "^1.8.1",
 				"@discordjs/collection": "1.5.3",
@@ -2874,9 +2874,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.779",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.779.tgz",
-			"integrity": "sha512-oaTiIcszNfySXVJzKcjxd2YjPxziAd+GmXyb2HbidCeFo6Z88ygOT7EimlrEQhM2U08VhSrbKhLOXP0kKUCZ6g==",
+			"version": "1.4.783",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz",
+			"integrity": "sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -4824,9 +4824,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
-			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
+			"version": "3.0.18",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
+			"integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
 			"dev": true
 		},
 		"node_modules/sprintf-js": {


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@babel/code-frame@7.24.2`](https://npmjs.com/package/@babel/code-frame/v/7.24.2) to [`7.24.6`](https://npmjs.com/package/@babel/code-frame/v/7.24.6) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-code-frame))
- Bumped [`@babel/helper-validator-identifier@7.24.5`](https://npmjs.com/package/@babel/helper-validator-identifier/v/7.24.5) to [`7.24.6`](https://npmjs.com/package/@babel/helper-validator-identifier/v/7.24.6) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-helper-validator-identifier))
- Bumped [`@babel/highlight@7.24.5`](https://npmjs.com/package/@babel/highlight/v/7.24.5) to [`7.24.6`](https://npmjs.com/package/@babel/highlight/v/7.24.6) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-highlight))
- Bumped [`@babel/runtime@7.24.5`](https://npmjs.com/package/@babel/runtime/v/7.24.5) to [`7.24.6`](https://npmjs.com/package/@babel/runtime/v/7.24.6) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-runtime))
- Bumped [`@discordjs/builders@1.8.2-dev.1716120217-b36ec9838`](https://npmjs.com/package/@discordjs/builders/v/1.8.2-dev.1716120217-b36ec9838) to [`1.8.2-dev.1716595776-a468ae8bb`](https://npmjs.com/package/@discordjs/builders/v/1.8.2-dev.1716595776-a468ae8bb) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/builders))
- Bumped [`@discordjs/formatters@0.4.1-dev.1716120229-b36ec9838`](https://npmjs.com/package/@discordjs/formatters/v/0.4.1-dev.1716120229-b36ec9838) to [`0.4.1-dev.1716595779-a468ae8bb`](https://npmjs.com/package/@discordjs/formatters/v/0.4.1-dev.1716595779-a468ae8bb) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.3.1-dev.1716120225-b36ec9838`](https://npmjs.com/package/@discordjs/rest/v/2.3.1-dev.1716120225-b36ec9838) to [`2.3.1-dev.1716595785-a468ae8bb`](https://npmjs.com/package/@discordjs/rest/v/2.3.1-dev.1716595785-a468ae8bb) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.1-dev.1716120216-b36ec9838`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1716120216-b36ec9838) to [`1.1.1-dev.1716595772-a468ae8bb`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1716595772-a468ae8bb) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@discordjs/ws@2.0.0-dev.1716120228-b36ec9838`](https://npmjs.com/package/@discordjs/ws/v/2.0.0-dev.1716120228-b36ec9838) to [`2.0.0-dev.1716595774-a468ae8bb`](https://npmjs.com/package/@discordjs/ws/v/2.0.0-dev.1716595774-a468ae8bb) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/ws))
- Bumped [`discord.js@14.15.3-dev.1716120217-b36ec9838`](https://npmjs.com/package/discord.js/v/14.15.3-dev.1716120217-b36ec9838) to [`14.15.3-dev.1716595781-a468ae8bb`](https://npmjs.com/package/discord.js/v/14.15.3-dev.1716595781-a468ae8bb) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/discord.js))
- Bumped [`electron-to-chromium@1.4.779`](https://npmjs.com/package/electron-to-chromium/v/1.4.779) to [`1.4.783`](https://npmjs.com/package/electron-to-chromium/v/1.4.783) ([see recent commits](https://github.com/kilian/electron-to-chromium))
- Bumped [`spdx-license-ids@3.0.17`](https://npmjs.com/package/spdx-license-ids/v/3.0.17) to [`3.0.18`](https://npmjs.com/package/spdx-license-ids/v/3.0.18) ([see recent commits](https://github.com/jslicense/spdx-license-ids))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
