### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,9 +1894,9 @@
 			}
 		},
 		"node_modules/@sapphire/snowflake": {
-			"version": "3.5.4-next.9ef6dfd8.0",
-			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.4-next.9ef6dfd8.0.tgz",
-			"integrity": "sha512-o1SH9HlVFsue8qoULIuaIE59MWzYfhDXLBJ7qSl0sZEAi7Mb5QV2uA3rLLAmRjID1yRbVger08B2A3/hI3eJ6Q==",
+			"version": "3.5.4-next.dda47af0.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.4-next.dda47af0.0.tgz",
+			"integrity": "sha512-7snlmeJE7iuH3uzb2JZax+JIbFohmUGBl8UyQ/EuVnSqa2APl2iAwq/2j1p8qX5+nlyjmeSNdyIjb12Jewfhwg==",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@sapphire/snowflake@3.5.4-next.9ef6dfd8.0`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.4-next.9ef6dfd8.0) to [`3.5.4-next.dda47af0.0`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.4-next.dda47af0.0) ([see recent commits](https://github.com/sapphiredev/utilities/commits/HEAD/packages/snowflake))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
