### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.8.2-dev.1716595776-a468ae8bb",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2-dev.1716595776-a468ae8bb.tgz",
-			"integrity": "sha512-q+eVB/qFVkRjVHpokBc5ZStbcOffMYwwsefjA6n9Wt+q38jkGdhHdL6u68PpqO0U6bjVTQXz5MAiD+XwwUwH0Q==",
+			"version": "1.8.2-dev.1716768630-d22b55fc8",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2-dev.1716768630-d22b55fc8.tgz",
+			"integrity": "sha512-ZaiEm+sIRwFzi/SPXHxtB0KTheqDStifSgg/CD9oVWpbnthybP0jIl8iWxetPXjd8a4Hb0o1J2wBmhOQIeOBoA==",
 			"dependencies": {
 				"@discordjs/formatters": "^0.4.0",
 				"@discordjs/util": "^1.1.0",
@@ -197,9 +197,9 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.4.1-dev.1716595779-a468ae8bb",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.1-dev.1716595779-a468ae8bb.tgz",
-			"integrity": "sha512-dQ42y5BSh4g3EGvyo77IXGKAycCTV9WWnEzO96j0OIA0TtV7I+zrqQWR1eO6QnCaOiWqvF5vMEG212vakbUcOQ==",
+			"version": "0.4.1-dev.1716768612-d22b55fc8",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.1-dev.1716768612-d22b55fc8.tgz",
+			"integrity": "sha512-kuXhathJ+pxaXCUBRcsmF5EIrTH8tPjz8gVwzVrLEYMsFW8zX+5ybKInLGTPTYXU7bbs4CsZ0B1oe049Qn1icA==",
 			"dependencies": {
 				"discord-api-types": "0.37.83"
 			},
@@ -211,9 +211,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.3.1-dev.1716595785-a468ae8bb",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.1-dev.1716595785-a468ae8bb.tgz",
-			"integrity": "sha512-kz1PUypMoYvMtdG6NlD7ctV/nTT/RORx0YVUCdEM5DAvxhsZxQe2TBOFtsb52u/xelKDRDFEqJn27PIzujuGyg==",
+			"version": "2.3.1-dev.1716768619-d22b55fc8",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.1-dev.1716768619-d22b55fc8.tgz",
+			"integrity": "sha512-TAiCzfSXCmBxDhT4qwsX7ZMqPs/aznTTvQCBHzvwzCNueyDJ2WxdvKo/IkwhFY4a+aiFx8wtOWHK7NUvNgWqzg==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/util": "^1.1.0",
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.1-dev.1716595772-a468ae8bb",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1716595772-a468ae8bb.tgz",
-			"integrity": "sha512-F3Gh5h6gI+Qn8h7z0QBoH6f5jmCStMqdZMLGbtsw3jr2lSkheRA9GQl/KKcApNf2/g/iCfy9T9KU2F7oN87pMQ==",
+			"version": "1.1.1-dev.1716768613-d22b55fc8",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1716768613-d22b55fc8.tgz",
+			"integrity": "sha512-F7pa9E+24NxZSKc98Qw4Ly4NRElo0GlIpQ50wVhd7enuT0gAdnfAnqLh3FgX84oxLZsadM5ZUVHa0MzyWqJjww==",
 			"engines": {
 				"node": ">=16.11.0"
 			},
@@ -244,9 +244,9 @@
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "2.0.0-dev.1716595774-a468ae8bb",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-2.0.0-dev.1716595774-a468ae8bb.tgz",
-			"integrity": "sha512-w/4jl+W7R2dbQq9bYZNFXCeTw+OdB8UO1vkGBdWLX4u/9r1oMc/sMW/G/WhCoEuno24sXTrQ59QmKlFfjklGNg==",
+			"version": "2.0.0-dev.1716768608-d22b55fc8",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-2.0.0-dev.1716768608-d22b55fc8.tgz",
+			"integrity": "sha512-vCvSZdGbfgw/lO8HT27WOuD5Lm4VQ+kuI9F3r5QYwG8+trwV8OFLTrDYlTMmaKg/biKsEyMjflOXvQ6kSYfQhQ==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/rest": "^2.3.0",
@@ -2535,9 +2535,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001621",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz",
-			"integrity": "sha512-+NLXZiviFFKX0fk8Piwv3PfLPGtRqJeq2TiNoUff/qB5KJgwecJTvCXDpmlyP/eCI/GUEmp/h/y5j0yckiiZrA==",
+			"version": "1.0.30001624",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz",
+			"integrity": "sha512-0dWnQG87UevOCPYaOR49CBcLBwoZLpws+k6W37nLjWUhumP1Isusj0p2u+3KhjNloRWK9OKMgjBBzPujQHw4nA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2786,9 +2786,9 @@
 			"integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
 		},
 		"node_modules/discord.js": {
-			"version": "14.15.3-dev.1716595781-a468ae8bb",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3-dev.1716595781-a468ae8bb.tgz",
-			"integrity": "sha512-Q5V8uObdwJLsmaDbmMoIdhUfJE9YAAOFhy+turJyfGkjRDvd4if4KSJRWrpuf45QqT8vzaSGI8VrbS0wEDTkBg==",
+			"version": "14.15.3-dev.1716768610-d22b55fc8",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3-dev.1716768610-d22b55fc8.tgz",
+			"integrity": "sha512-/PxKSe+rZsI4HmxvjYi77DKXdpSb12RMMNJVpRvY491W9MYUBA9mzkWu8HntS60YbX38ZK+8b/ODY4OTnbma5A==",
 			"dependencies": {
 				"@discordjs/builders": "^1.8.1",
 				"@discordjs/collection": "1.5.3",


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/builders@1.8.2-dev.1716595776-a468ae8bb`](https://npmjs.com/package/@discordjs/builders/v/1.8.2-dev.1716595776-a468ae8bb) to [`1.8.2-dev.1716768630-d22b55fc8`](https://npmjs.com/package/@discordjs/builders/v/1.8.2-dev.1716768630-d22b55fc8) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/builders))
- Bumped [`@discordjs/formatters@0.4.1-dev.1716595779-a468ae8bb`](https://npmjs.com/package/@discordjs/formatters/v/0.4.1-dev.1716595779-a468ae8bb) to [`0.4.1-dev.1716768612-d22b55fc8`](https://npmjs.com/package/@discordjs/formatters/v/0.4.1-dev.1716768612-d22b55fc8) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.3.1-dev.1716595785-a468ae8bb`](https://npmjs.com/package/@discordjs/rest/v/2.3.1-dev.1716595785-a468ae8bb) to [`2.3.1-dev.1716768619-d22b55fc8`](https://npmjs.com/package/@discordjs/rest/v/2.3.1-dev.1716768619-d22b55fc8) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.1-dev.1716595772-a468ae8bb`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1716595772-a468ae8bb) to [`1.1.1-dev.1716768613-d22b55fc8`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1716768613-d22b55fc8) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@discordjs/ws@2.0.0-dev.1716595774-a468ae8bb`](https://npmjs.com/package/@discordjs/ws/v/2.0.0-dev.1716595774-a468ae8bb) to [`2.0.0-dev.1716768608-d22b55fc8`](https://npmjs.com/package/@discordjs/ws/v/2.0.0-dev.1716768608-d22b55fc8) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/ws))
- Bumped [`caniuse-lite@1.0.30001621`](https://npmjs.com/package/caniuse-lite/v/1.0.30001621) to [`1.0.30001624`](https://npmjs.com/package/caniuse-lite/v/1.0.30001624) ([see recent commits](https://github.com/browserslist/caniuse-lite))
- Bumped [`discord.js@14.15.3-dev.1716595781-a468ae8bb`](https://npmjs.com/package/discord.js/v/14.15.3-dev.1716595781-a468ae8bb) to [`14.15.3-dev.1716768610-d22b55fc8`](https://npmjs.com/package/discord.js/v/14.15.3-dev.1716768610-d22b55fc8) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/discord.js))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
