### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 			},
 			"engines": {
 				"node": "^20.10.0",
-				"npm": "^8.0.0"
+				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
 				"@napi-rs/canvas": "0.1.53",
@@ -49,12 +49,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.6.tgz",
-			"integrity": "sha512-ZJhac6FkEd1yhG2AHOmfcXG4ceoLltoCVJjN5XsWN9BifBQr+cHJbWi0h68HZuSORq+3WtJ2z0hwF2NG1b5kcA==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.24.6",
+				"@babel/highlight": "^7.24.7",
 				"picocolors": "^1.0.0"
 			},
 			"engines": {
@@ -62,21 +62,21 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.6.tgz",
-			"integrity": "sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.6.tgz",
-			"integrity": "sha512-2YnuOp4HAk2BsBrJJvYCbItHx0zWscI1C3zgWkz+wDyD9I7GIVrfnLyrR4Y1VR+7p+chAEcrgRQYZAGIKMV7vQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.24.6",
+				"@babel/helper-validator-identifier": "^7.24.7",
 				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.0.0"
@@ -157,9 +157,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
-			"integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+			"integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -168,14 +168,14 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.8.2-dev.1716768630-d22b55fc8",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.8.2-dev.1716768630-d22b55fc8.tgz",
-			"integrity": "sha512-ZaiEm+sIRwFzi/SPXHxtB0KTheqDStifSgg/CD9oVWpbnthybP0jIl8iWxetPXjd8a4Hb0o1J2wBmhOQIeOBoA==",
+			"version": "1.9.0-dev.1723162248-432e9b842",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.9.0-dev.1723162248-432e9b842.tgz",
+			"integrity": "sha512-+BhMWgKylYUdsCR9FCM8vHcfiGaXX4Rqi3Rzy9jwRKeFgoGQ9o+wSov1Udl1/Vo+JqYLrQyJmAKByCe3A7Z+Qg==",
 			"dependencies": {
 				"@discordjs/formatters": "^0.4.0",
 				"@discordjs/util": "^1.1.0",
 				"@sapphire/shapeshift": "^3.9.7",
-				"discord-api-types": "0.37.83",
+				"discord-api-types": "0.37.93",
 				"fast-deep-equal": "^3.1.3",
 				"ts-mixer": "^6.0.4",
 				"tslib": "^2.6.2"
@@ -197,11 +197,11 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.4.1-dev.1716768612-d22b55fc8",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.4.1-dev.1716768612-d22b55fc8.tgz",
-			"integrity": "sha512-kuXhathJ+pxaXCUBRcsmF5EIrTH8tPjz8gVwzVrLEYMsFW8zX+5ybKInLGTPTYXU7bbs4CsZ0B1oe049Qn1icA==",
+			"version": "0.5.0-dev.1723162254-432e9b842",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.5.0-dev.1723162254-432e9b842.tgz",
+			"integrity": "sha512-6NwU5y7HhHtrvg0KFIGN3QSwp/vkK87rkx80iXVvU5bYGowoaQLIvHCfzPPbguxzi3DzM1Z5pebHuFHG30G+Rg==",
 			"dependencies": {
-				"discord-api-types": "0.37.83"
+				"discord-api-types": "0.37.93"
 			},
 			"engines": {
 				"node": ">=16.11.0"
@@ -211,19 +211,19 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.3.1-dev.1716768619-d22b55fc8",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.3.1-dev.1716768619-d22b55fc8.tgz",
-			"integrity": "sha512-TAiCzfSXCmBxDhT4qwsX7ZMqPs/aznTTvQCBHzvwzCNueyDJ2WxdvKo/IkwhFY4a+aiFx8wtOWHK7NUvNgWqzg==",
+			"version": "2.4.0-dev.1723162253-432e9b842",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0-dev.1723162253-432e9b842.tgz",
+			"integrity": "sha512-AyKYtfqYQOoNdnTWFx7R9t9KlXCjDmjk3TDVynh53yx9CvTyjRQzNuK/xid+D1fiQaBUkf+6CkdCBm+NBTSQ/w==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/util": "^1.1.0",
 				"@sapphire/async-queue": "^1.5.2",
 				"@sapphire/snowflake": "^3.5.3",
 				"@vladfrangu/async_event_emitter": "^2.2.4",
-				"discord-api-types": "0.37.83",
+				"discord-api-types": "0.37.93",
 				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.2",
-				"undici": "6.13.0"
+				"undici": "6.18.2"
 			},
 			"engines": {
 				"node": ">=16.11.0"
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.1-dev.1716768613-d22b55fc8",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1716768613-d22b55fc8.tgz",
-			"integrity": "sha512-F7pa9E+24NxZSKc98Qw4Ly4NRElo0GlIpQ50wVhd7enuT0gAdnfAnqLh3FgX84oxLZsadM5ZUVHa0MzyWqJjww==",
+			"version": "1.1.1-dev.1723162253-432e9b842",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1-dev.1723162253-432e9b842.tgz",
+			"integrity": "sha512-FGUCeJ660Ul930QNSa5X5krNHWE1L/Sx1W/87rjuFH1ubZwMk4Btp0HGuFtIHp1H3Kyv3yz9865fMS0ZZN27ig==",
 			"engines": {
 				"node": ">=16.11.0"
 			},
@@ -244,9 +244,9 @@
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "2.0.0-dev.1716768608-d22b55fc8",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-2.0.0-dev.1716768608-d22b55fc8.tgz",
-			"integrity": "sha512-vCvSZdGbfgw/lO8HT27WOuD5Lm4VQ+kuI9F3r5QYwG8+trwV8OFLTrDYlTMmaKg/biKsEyMjflOXvQ6kSYfQhQ==",
+			"version": "2.0.0-dev.1723162252-432e9b842",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-2.0.0-dev.1723162252-432e9b842.tgz",
+			"integrity": "sha512-9OuRQ2JnNgoQGbiqtrONdIza4EoYZVrRHyb+gXY9FQIIXM5JuGTnMtA0T9AWHmKGLVg1H4SET4LyS653Pimfgw==",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/rest": "^2.3.0",
@@ -254,9 +254,9 @@
 				"@sapphire/async-queue": "^1.5.2",
 				"@types/ws": "^8.5.10",
 				"@vladfrangu/async_event_emitter": "^2.2.4",
-				"discord-api-types": "0.37.83",
+				"discord-api-types": "0.37.93",
 				"tslib": "^2.6.2",
-				"ws": "^8.16.0"
+				"ws": "^8.17.0"
 			},
 			"engines": {
 				"node": ">=16.11.0"
@@ -281,9 +281,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+			"integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
 			"dev": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -352,6 +352,7 @@
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
 			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"deprecated": "Use @eslint/config-array instead",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^2.0.2",
@@ -401,6 +402,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true
 		},
 		"node_modules/@khanacademy/perseus-core": {
@@ -427,9 +429,9 @@
 			"optional": true
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.7.tgz",
-			"integrity": "sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==",
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.8.tgz",
+			"integrity": "sha512-qKwC/M/nNNaKUBMQ0nuzm47b7ZYWQHN3pcXq4IIcoSBc2hOIrflAxJduIvvqmhoz3gR2TacTAs8vlsCVPkiEdQ==",
 			"optional": true,
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
@@ -1766,9 +1768,9 @@
 			"integrity": "sha512-ckIq4D8SMXyMz8K4Muzsk92HY1k4i4dAMobO/65ne9fqGsquxuRJDo+Js273EtcO+8nMFmhWk/zjRo5Toyjggg=="
 		},
 		"node_modules/@sapphire/async-queue": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.2.tgz",
-			"integrity": "sha512-7X7FFAA4DngXUl95+hYbUF19bp1LGiffjJtu7ygrZrbdCSsdDDBaSjB7Akw0ZbOu6k0xpXyljnJ6/RZUvLfRdg==",
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
+			"integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -1787,9 +1789,9 @@
 			}
 		},
 		"node_modules/@sapphire/snowflake": {
-			"version": "3.5.4-next.dda47af0.0",
-			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.4-next.dda47af0.0.tgz",
-			"integrity": "sha512-7snlmeJE7iuH3uzb2JZax+JIbFohmUGBl8UyQ/EuVnSqa2APl2iAwq/2j1p8qX5+nlyjmeSNdyIjb12Jewfhwg==",
+			"version": "3.5.4-next.8bfb0191",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.4-next.8bfb0191.tgz",
+			"integrity": "sha512-QCTt5xFgx1CkzZiuwdsXZrF7cs4DlHq+C38N5clKpbqW9gW3IFUdq+odeliF2pp3cwl6tZZDBn0rmh1x3EPf2w==",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -1807,9 +1809,9 @@
 			"dev": true
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.56.10",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
-			"integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+			"version": "8.56.11",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
+			"integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -1872,9 +1874,9 @@
 			}
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-			"integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+			"integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -2230,18 +2232,18 @@
 			"dev": true
 		},
 		"node_modules/@vladfrangu/async_event_emitter": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
-			"integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.5.tgz",
+			"integrity": "sha512-J7T3gUr3Wz0l7Ni1f9upgBZ7+J22/Q1B7dl0X6fG+fTsD+H+31DIosMHj4Um1dWQwqbcQ3oQf+YS2foYkDc9cQ==",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2367,9 +2369,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-			"integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+			"version": "4.23.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+			"integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2386,10 +2388,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001587",
-				"electron-to-chromium": "^1.4.668",
-				"node-releases": "^2.0.14",
-				"update-browserslist-db": "^1.0.13"
+				"caniuse-lite": "^1.0.30001646",
+				"electron-to-chromium": "^1.5.4",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.0"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -2428,9 +2430,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001624",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001624.tgz",
-			"integrity": "sha512-0dWnQG87UevOCPYaOR49CBcLBwoZLpws+k6W37nLjWUhumP1Isusj0p2u+3KhjNloRWK9OKMgjBBzPujQHw4nA==",
+			"version": "1.0.30001651",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
+			"integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2581,12 +2583,12 @@
 			"dev": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.37.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
-			"integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.0.tgz",
+			"integrity": "sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.23.0"
+				"browserslist": "^4.23.3"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2617,9 +2619,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -2674,27 +2676,27 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.83",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
-			"integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA=="
+			"version": "0.37.93",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.93.tgz",
+			"integrity": "sha512-M5jn0x3bcXk8EI2c6F6V6LeOWq10B/cJf+YJSyqNmg7z4bdXK+Z7g9zGJwHS0h9Bfgs0nun2LQISFOzwck7G9A=="
 		},
 		"node_modules/discord.js": {
-			"version": "14.15.3-dev.1716768610-d22b55fc8",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.15.3-dev.1716768610-d22b55fc8.tgz",
-			"integrity": "sha512-/PxKSe+rZsI4HmxvjYi77DKXdpSb12RMMNJVpRvY491W9MYUBA9mzkWu8HntS60YbX38ZK+8b/ODY4OTnbma5A==",
+			"version": "14.16.0-dev.1723162257-432e9b842",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.0-dev.1723162257-432e9b842.tgz",
+			"integrity": "sha512-abNeoGW5S4R1dnYXKTxtoRUqo9+lefXa78LeDYrUpURzV3if4twwF5vHtfEjcX+w9l56LMuZaPEAkNG3b2lIMw==",
 			"dependencies": {
-				"@discordjs/builders": "^1.8.1",
+				"@discordjs/builders": "^1.8.2",
 				"@discordjs/collection": "1.5.3",
 				"@discordjs/formatters": "^0.4.0",
 				"@discordjs/rest": "^2.3.0",
 				"@discordjs/util": "^1.1.0",
-				"@discordjs/ws": "^1.1.0",
+				"@discordjs/ws": "1.1.1",
 				"@sapphire/snowflake": "3.5.3",
-				"discord-api-types": "0.37.83",
+				"discord-api-types": "0.37.93",
 				"fast-deep-equal": "3.1.3",
 				"lodash.snakecase": "4.1.1",
 				"tslib": "2.6.2",
-				"undici": "6.13.0"
+				"undici": "6.18.2"
 			},
 			"engines": {
 				"node": ">=16.11.0"
@@ -2767,9 +2769,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.783",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz",
-			"integrity": "sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ==",
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.6.tgz",
+			"integrity": "sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -2969,9 +2971,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -3367,9 +3369,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -3478,12 +3480,15 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+			"integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
 			"dev": true,
 			"dependencies": {
-				"hasown": "^2.0.0"
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3728,9 +3733,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -3939,9 +3944,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
 			"dev": true
 		},
 		"node_modules/nodemon": {
@@ -4578,9 +4583,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -4925,11 +4930,11 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.13.0.tgz",
-			"integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==",
+			"version": "6.18.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
+			"integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {
@@ -4938,9 +4943,9 @@
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.16",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-			"integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+			"integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5046,9 +5051,9 @@
 			"dev": true
 		},
 		"node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"engines": {
 				"node": ">=10.0.0"
 			},


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@babel/code-frame@7.24.6`](https://npmjs.com/package/@babel/code-frame/v/7.24.6) to [`7.24.7`](https://npmjs.com/package/@babel/code-frame/v/7.24.7) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-code-frame))
- Bumped [`@babel/helper-validator-identifier@7.24.6`](https://npmjs.com/package/@babel/helper-validator-identifier/v/7.24.6) to [`7.24.7`](https://npmjs.com/package/@babel/helper-validator-identifier/v/7.24.7) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-helper-validator-identifier))
- Bumped [`@babel/highlight@7.24.6`](https://npmjs.com/package/@babel/highlight/v/7.24.6) to [`7.24.7`](https://npmjs.com/package/@babel/highlight/v/7.24.7) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-highlight))
- Bumped [`@babel/runtime@7.24.6`](https://npmjs.com/package/@babel/runtime/v/7.24.6) to [`7.25.0`](https://npmjs.com/package/@babel/runtime/v/7.25.0) ([see recent commits](https://github.com/babel/babel/commits/HEAD/packages/babel-runtime))
- Bumped [`@discordjs/builders@1.8.2-dev.1716768630-d22b55fc8`](https://npmjs.com/package/@discordjs/builders/v/1.8.2-dev.1716768630-d22b55fc8) to [`1.9.0-dev.1723162248-432e9b842`](https://npmjs.com/package/@discordjs/builders/v/1.9.0-dev.1723162248-432e9b842) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/builders))
- Bumped [`@discordjs/formatters@0.4.1-dev.1716768612-d22b55fc8`](https://npmjs.com/package/@discordjs/formatters/v/0.4.1-dev.1716768612-d22b55fc8) to [`0.5.0-dev.1723162254-432e9b842`](https://npmjs.com/package/@discordjs/formatters/v/0.5.0-dev.1723162254-432e9b842) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.3.1-dev.1716768619-d22b55fc8`](https://npmjs.com/package/@discordjs/rest/v/2.3.1-dev.1716768619-d22b55fc8) to [`2.4.0-dev.1723162253-432e9b842`](https://npmjs.com/package/@discordjs/rest/v/2.4.0-dev.1723162253-432e9b842) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.1-dev.1716768613-d22b55fc8`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1716768613-d22b55fc8) to [`1.1.1-dev.1723162253-432e9b842`](https://npmjs.com/package/@discordjs/util/v/1.1.1-dev.1723162253-432e9b842) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@discordjs/ws@2.0.0-dev.1716768608-d22b55fc8`](https://npmjs.com/package/@discordjs/ws/v/2.0.0-dev.1716768608-d22b55fc8) to [`2.0.0-dev.1723162252-432e9b842`](https://npmjs.com/package/@discordjs/ws/v/2.0.0-dev.1723162252-432e9b842) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/ws))
- Bumped [`@eslint-community/regexpp@4.10.0`](https://npmjs.com/package/@eslint-community/regexpp/v/4.10.0) to [`4.11.0`](https://npmjs.com/package/@eslint-community/regexpp/v/4.11.0) ([see recent commits](https://github.com/eslint-community/regexpp))
- Bumped [`@mongodb-js/saslprep@1.1.7`](https://npmjs.com/package/@mongodb-js/saslprep/v/1.1.7) to [`1.1.8`](https://npmjs.com/package/@mongodb-js/saslprep/v/1.1.8) ([see recent commits](https://github.com/mongodb-js/devtools-shared))
- Bumped [`@sapphire/async-queue@1.5.2`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.2) to [`1.5.3`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.3) ([see recent commits](https://github.com/sapphiredev/utilities/commits/HEAD/packages/async-queue))
- Bumped [`@sapphire/snowflake@3.5.4-next.dda47af0.0`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.4-next.dda47af0.0) to [`3.5.4-next.8bfb0191`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.4-next.8bfb0191) ([see recent commits](https://github.com/sapphiredev/utilities/commits/HEAD/packages/snowflake))
- Bumped [`@types/eslint@8.56.10`](https://npmjs.com/package/@types/eslint/v/8.56.10) to [`8.56.11`](https://npmjs.com/package/@types/eslint/v/8.56.11) ([see recent commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/eslint))
- Bumped [`@types/ws@8.5.10`](https://npmjs.com/package/@types/ws/v/8.5.10) to [`8.5.12`](https://npmjs.com/package/@types/ws/v/8.5.12) ([see recent commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/ws))
- Bumped [`@vladfrangu/async_event_emitter@2.2.4`](https://npmjs.com/package/@vladfrangu/async_event_emitter/v/2.2.4) to [`2.4.5`](https://npmjs.com/package/@vladfrangu/async_event_emitter/v/2.4.5) ([see recent commits](https://github.com/vladfrangu/async_event_emitter))
- Bumped [`acorn@8.11.3`](https://npmjs.com/package/acorn/v/8.11.3) to [`8.12.1`](https://npmjs.com/package/acorn/v/8.12.1) ([see recent commits](https://github.com/acornjs/acorn))
- Bumped [`browserslist@4.23.0`](https://npmjs.com/package/browserslist/v/4.23.0) to [`4.23.3`](https://npmjs.com/package/browserslist/v/4.23.3) ([see recent commits](https://github.com/browserslist/browserslist))
- Bumped [`caniuse-lite@1.0.30001624`](https://npmjs.com/package/caniuse-lite/v/1.0.30001624) to [`1.0.30001651`](https://npmjs.com/package/caniuse-lite/v/1.0.30001651) ([see recent commits](https://github.com/browserslist/caniuse-lite))
- Bumped [`core-js-compat@3.37.1`](https://npmjs.com/package/core-js-compat/v/3.37.1) to [`3.38.0`](https://npmjs.com/package/core-js-compat/v/3.38.0) ([see recent commits](https://github.com/zloirock/core-js/commits/HEAD/packages/core-js-compat))
- Bumped [`debug@4.3.4`](https://npmjs.com/package/debug/v/4.3.4) to [`4.3.6`](https://npmjs.com/package/debug/v/4.3.6) ([see recent commits](https://github.com/debug-js/debug))
- Bumped [`discord-api-types@0.37.83`](https://npmjs.com/package/discord-api-types/v/0.37.83) to [`0.37.93`](https://npmjs.com/package/discord-api-types/v/0.37.93) ([see recent commits](https://github.com/discordjs/discord-api-types))
- Bumped [`discord.js@14.15.3-dev.1716768610-d22b55fc8`](https://npmjs.com/package/discord.js/v/14.15.3-dev.1716768610-d22b55fc8) to [`14.16.0-dev.1723162257-432e9b842`](https://npmjs.com/package/discord.js/v/14.16.0-dev.1723162257-432e9b842) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/discord.js))
- Bumped [`electron-to-chromium@1.4.783`](https://npmjs.com/package/electron-to-chromium/v/1.4.783) to [`1.5.6`](https://npmjs.com/package/electron-to-chromium/v/1.5.6) ([see recent commits](https://github.com/kilian/electron-to-chromium))
- Bumped [`esquery@1.5.0`](https://npmjs.com/package/esquery/v/1.5.0) to [`1.6.0`](https://npmjs.com/package/esquery/v/1.6.0) ([see recent commits](https://github.com/estools/esquery))
- Bumped [`ignore@5.3.1`](https://npmjs.com/package/ignore/v/5.3.1) to [`5.3.2`](https://npmjs.com/package/ignore/v/5.3.2) ([see recent commits](https://github.com/kaelzhang/node-ignore))
- Bumped [`is-core-module@2.13.1`](https://npmjs.com/package/is-core-module/v/2.13.1) to [`2.15.0`](https://npmjs.com/package/is-core-module/v/2.15.0) ([see recent commits](https://github.com/inspect-js/is-core-module))
- Bumped [`minimatch@9.0.4`](https://npmjs.com/package/minimatch/v/9.0.4) to [`9.0.5`](https://npmjs.com/package/minimatch/v/9.0.5) ([see recent commits](https://github.com/isaacs/minimatch))
- Bumped [`node-releases@2.0.14`](https://npmjs.com/package/node-releases/v/2.0.14) to [`2.0.18`](https://npmjs.com/package/node-releases/v/2.0.18) ([see recent commits](https://github.com/chicoxyzzy/node-releases))
- Bumped [`semver@7.6.2`](https://npmjs.com/package/semver/v/7.6.2) to [`7.6.3`](https://npmjs.com/package/semver/v/7.6.3) ([see recent commits](https://github.com/npm/node-semver))
- Bumped [`undici@6.13.0`](https://npmjs.com/package/undici/v/6.13.0) to [`6.18.2`](https://npmjs.com/package/undici/v/6.18.2) ([see recent commits](https://github.com/nodejs/undici))
- Bumped [`update-browserslist-db@1.0.16`](https://npmjs.com/package/update-browserslist-db/v/1.0.16) to [`1.1.0`](https://npmjs.com/package/update-browserslist-db/v/1.1.0) ([see recent commits](https://github.com/browserslist/update-db))
- Bumped [`ws@8.17.1`](https://npmjs.com/package/ws/v/8.17.1) to [`8.18.0`](https://npmjs.com/package/ws/v/8.18.0) ([see recent commits](https://github.com/websockets/ws))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
